### PR TITLE
Use map definition for key and value sizes instead of arguments

### DIFF
--- a/selftest/iterators/main.go
+++ b/selftest/iterators/main.go
@@ -44,7 +44,7 @@ func main() {
 		}
 	}
 
-	iterator := numbers.Iterator(4) // 4 is size of uint32 in bytes
+	iterator := numbers.Iterator()
 	for iterator.Next() {
 		keyBytes := iterator.Key()
 		key := determineHostByteOrder().Uint32(keyBytes)


### PR DESCRIPTION
Previously this was quite error prone and somewhat unnecessary, as one
had to keep sizes consistent in Go and C code, but we can actually read
the sizes from the map definition improving developer experience and
making the API less error prone.

Already verified these changes in my usage of libbpfgo.

@grantseltzer @yanivagman @eyakubovich 