### PR TITLE
Uprobe support

### DIFF
--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -2,13 +2,13 @@ package helpers
 
 import (
 	"debug/elf"
+	"errors"
 	"fmt"
 )
 
-// SymbolToOffset attempts to resolve a 'symbol' name within a specific
-// 'section' of the binary found at 'path' to an offset. The offset
-// can be used for attaching a u(ret)probe
-func SymbolToOffset(path, section, symbol string) (uint32, error) {
+// SymbolToOffset attempts to resolve a 'symbol' name in the binary found at
+// 'path' to an offset. The offset can be used for attaching a u(ret)probe
+func SymbolToOffset(path, symbol string) (uint32, error) {
 
 	f, err := elf.Open(path)
 	if err != nil {
@@ -20,14 +20,32 @@ func SymbolToOffset(path, section, symbol string) (uint32, error) {
 		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %v", err)
 	}
 
-	textSection := f.Section(section)
-	if textSection == nil {
-		return 0, fmt.Errorf("could not calculate start of text section in binary")
+	sectionsToSearchForSymbol := []*elf.Section{}
+
+	for i := range f.Sections {
+		if f.Sections[i].Flags == elf.SHF_ALLOC+elf.SHF_EXECINSTR {
+			sectionsToSearchForSymbol = append(sectionsToSearchForSymbol, f.Sections[i])
+		}
 	}
 
+	var executableSection *elf.Section
 	for i := range syms {
 		if syms[i].Name == symbol {
-			return uint32(syms[i].Value - textSection.Addr + textSection.Offset), nil
+
+			// Find what section the symbol is in by checking the executable section's
+			// addr space.
+			for m := range sectionsToSearchForSymbol {
+				if syms[i].Value > sectionsToSearchForSymbol[m].Addr &&
+					syms[i].Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
+					executableSection = sectionsToSearchForSymbol[m]
+				}
+			}
+
+			if executableSection == nil {
+				return 0, errors.New("could not find symbol in executable sections of binary")
+			}
+
+			return uint32(syms[i].Value - executableSection.Addr + executableSection.Offset), nil
 		}
 	}
 	return 0, fmt.Errorf("symbol not found")

--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -1,0 +1,34 @@
+package helpers
+
+import (
+	"debug/elf"
+	"fmt"
+)
+
+// SymbolToOffset attempts to resolve a 'symbol' name within a specific
+// 'section' of the binary found at 'path' to an offset. The offset
+// can be used for attaching a u(ret)probe
+func SymbolToOffset(path, section, symbol string) (uint32, error) {
+
+	f, err := elf.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %v", err)
+	}
+
+	syms, err := f.Symbols()
+	if err != nil {
+		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %v", err)
+	}
+
+	textSection := f.Section(section)
+	if textSection == nil {
+		return 0, fmt.Errorf("could not calculate start of text section in binary")
+	}
+
+	for i := range syms {
+		if syms[i].Name == symbol {
+			return uint32(syms[i].Value - textSection.Addr + textSection.Offset), nil
+		}
+	}
+	return 0, fmt.Errorf("symbol not found")
+}

--- a/selftest/.gitignore
+++ b/selftest/.gitignore
@@ -1,1 +1,4 @@
 dist
+self.bpf.o
+vmlinux.h
+self

--- a/selftest/uprobe/Makefile
+++ b/selftest/uprobe/Makefile
@@ -1,0 +1,40 @@
+TARGET := self
+TARGET_BPF := $(TARGET).bpf.o
+
+TEST_GO_SRC := test_program/test_program.go
+TEST_C_SRC := test_program/test_program.c
+TEST_C_OBJ := test_program/dist/test_c_object
+TEST_GO_OBJ := test_program/dist/test_go_object
+
+GO_SRC := $(shell find . -type f -name '*.go')
+LIBBPFGO_SRC := $(shell find ../.. -type f -name '*.go')
+BPF_SRC := $(shell find . -type f -name '*.bpf.c')
+PWD := $(shell pwd)
+
+LIBBPF_HEADERS := /usr/include/bpf
+LIBBPF_OBJ := $(abspath ../dist/libbpf.a)
+
+.PHONY: all
+all: vmlinux.h $(TARGET) $(TARGET_BPF) $(TEST_GO_OBJ) $(TEST_C_OBJ)
+
+vmlinux.h:
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+
+$(TEST_C_OBJ): $(TEST_C_SRC)
+	clang $(TEST_C_SRC) -o $(TEST_C_OBJ)
+
+$(TEST_GO_OBJ): $(TEST_GO_SRC)
+	go build -o $(TEST_GO_OBJ) $(TEST_GO_SRC)
+
+go_env := CC=gcc CGO_CFLAGS="-I $(LIBBPF_HEADERS)" CGO_LDFLAGS="$(LIBBPF_OBJ)"
+$(TARGET): $(GO_SRC) $(LIBBPFGO_SRC)
+	$(go_env) go build -ldflags '-extldflags "-static"' -o $(TARGET) 
+
+$(TARGET_BPF): $(BPF_SRC)
+	clang \
+		-g -O2 -c -target bpf \
+		-o $@ $<
+
+.PHONY: clean
+clean: 
+	rm $(TARGET) $(TARGET_BPF) $(TEST_GO_OBJ) $(TEST_C_OBJ) vmlinux.h

--- a/selftest/uprobe/go.mod
+++ b/selftest/uprobe/go.mod
@@ -1,0 +1,10 @@
+module github.com/aquasecurity/libbpfgo/selftest/uprobe
+
+go 1.16
+
+require (
+	github.com/aquasecurity/libbpfgo v0.1.0
+	github.com/iovisor/gobpf v0.2.0 // indirect
+)
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/uprobe/go.mod
+++ b/selftest/uprobe/go.mod
@@ -2,9 +2,6 @@ module github.com/aquasecurity/libbpfgo/selftest/uprobe
 
 go 1.16
 
-require (
-	github.com/aquasecurity/libbpfgo v0.1.0
-	github.com/iovisor/gobpf v0.2.0 // indirect
-)
+require github.com/aquasecurity/libbpfgo v0.1.0
 
 replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/uprobe/go.sum
+++ b/selftest/uprobe/go.sum
@@ -1,0 +1,16 @@
+github.com/aquasecurity/libbpfgo v0.1.0 h1:14V7ISF45XVqwBre+7NCDByy77OuwFgzDjVR+0JltZ8=
+github.com/aquasecurity/libbpfgo v0.1.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/iovisor/gobpf v0.2.0 h1:34xkQxft+35GagXBk3n23eqhm0v7q0ejeVirb8sqEOQ=
+github.com/iovisor/gobpf v0.2.0/go.mod h1:WSY9Jj5RhdgC3ci1QaacvbFdQ8cbrEjrpiZbLHLt2s4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/uprobe/go.sum
+++ b/selftest/uprobe/go.sum
@@ -1,9 +1,5 @@
-github.com/aquasecurity/libbpfgo v0.1.0 h1:14V7ISF45XVqwBre+7NCDByy77OuwFgzDjVR+0JltZ8=
-github.com/aquasecurity/libbpfgo v0.1.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/iovisor/gobpf v0.2.0 h1:34xkQxft+35GagXBk3n23eqhm0v7q0ejeVirb8sqEOQ=
-github.com/iovisor/gobpf v0.2.0/go.mod h1:WSY9Jj5RhdgC3ci1QaacvbFdQ8cbrEjrpiZbLHLt2s4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/selftest/uprobe/main.go
+++ b/selftest/uprobe/main.go
@@ -51,7 +51,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	offset, err := helpers.SymbolToOffset(binaryPath, ".text", symbolName)
+	offset, err := helpers.SymbolToOffset(binaryPath, symbolName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)

--- a/selftest/uprobe/main.go
+++ b/selftest/uprobe/main.go
@@ -1,0 +1,96 @@
+package main
+
+import "C"
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/libbpfgo/helpers"
+)
+
+func resizeMap(module *bpf.Module, name string, size uint32) error {
+	m, err := module.GetMap("events")
+	if err != nil {
+		return err
+	}
+
+	if err = m.Resize(size); err != nil {
+		return err
+	}
+
+	if actual := m.GetMaxEntries(); actual != size {
+		return fmt.Errorf("map resize failed, expected %v, actual %v", size, actual)
+	}
+
+	return nil
+}
+
+func main() {
+
+	binaryPath := os.Args[1]
+	symbolName := os.Args[2]
+
+	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	bpfModule.BPFLoadObject()
+	prog, err := bpfModule.GetProgram("uprobe__test_function")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	offset, err := helpers.SymbolToOffset(binaryPath, ".text", symbolName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	_, err = prog.AttachUprobe(-1, binaryPath, offset)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	eventsChannel := make(chan []byte)
+	rb, err := bpfModule.InitRingBuf("events", eventsChannel)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	rb.Start()
+
+	numberOfEventsReceived := 0
+
+recvLoop:
+	for {
+		b := <-eventsChannel
+		if binary.LittleEndian.Uint32(b) != 2021 {
+			fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+			os.Exit(-1)
+		}
+		numberOfEventsReceived++
+		if numberOfEventsReceived > 5 {
+			break recvLoop
+		}
+	}
+
+	// Test that it won't cause a panic or block if Stop or Close called multiple times
+	rb.Stop()
+	rb.Stop()
+	rb.Close()
+	rb.Close()
+	rb.Stop()
+}

--- a/selftest/uprobe/run.sh
+++ b/selftest/uprobe/run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' 
+
+VERSION_LIMIT=4.3
+CURRENT_VERSION=$(uname -r | cut -d '.' -f1-2)
+
+GO_TEST_PROGRAM='./test_program/dist/test_go_object'
+GO_TEST_SYMBOL='main.testFunction'
+
+C_TEST_PROGRAM='./test_program/dist/test_c_object'
+C_TEST_SYMBOL='testFunction'
+
+# Check that kernel version is big enough
+if [ $(echo "$CURRENT_VERSION"$'\n'"$VERSION_LIMIT" | sort -V | head -n1) != "$VERSION_LIMIT" ]; then
+    echo -e "${RED}[*] OUTDATED KERNEL VERSION${NC}"
+    exit 1
+fi
+
+make -f $PWD/Makefile
+if [ $? -ne 0 ]; then
+    echo -e "${RED}[*] MAKE FAILED"
+    exit 2
+else
+    echo -e "${GREEN}[*] MAKE RAN SUCCESFULLY${NC}"
+fi
+
+$GO_TEST_PROGRAM&
+timeout 5 ./self $GO_TEST_PROGRAM $GO_TEST_SYMBOL
+
+RETURN_CODE=$?
+if [ $RETURN_CODE -eq 124 ]; then
+    echo -e "${RED}[*] SELFTEST TIMEDOUT${NC}"
+    exit 3
+fi
+
+$C_TEST_PROGRAM&
+timeout 5 $PWD/self $C_TEST_PROGRAM $C_TEST_SYMBOL
+RETURN_CODE=$?
+if [ $RETURN_CODE -eq 124 ]; then
+    echo -e "${RED}[*] SELFTEST TIMEDOUT${NC}"
+    exit 3
+fi
+
+if [ $RETURN_CODE -ne 0 ]; then
+    echo -e "${RED}[*] ERROR IN SELFTEST${NC}"
+    exit 4
+fi
+
+echo -e "${GREEN}[*] SUCCESS${NC}"
+exit 0

--- a/selftest/uprobe/self.bpf.c
+++ b/selftest/uprobe/self.bpf.c
@@ -1,0 +1,32 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>  
+
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 24);
+} events SEC(".maps");
+
+long ringbuffer_flags = 0;
+
+SEC("uprobe/test_function")
+int uprobe__test_function(struct pt_regs *ctx)
+{
+    int *process;
+
+    // Reserve space on the ringbuffer for the sample
+    process = bpf_ringbuf_reserve(&events, sizeof(int), ringbuffer_flags);
+    if (!process) {
+        return 0;
+    }
+
+    *process = 2021;
+
+    bpf_ringbuf_submit(process, ringbuffer_flags);
+    return 0;
+}

--- a/selftest/uprobe/test_program/test_program.c
+++ b/selftest/uprobe/test_program/test_program.c
@@ -1,0 +1,12 @@
+//+build ignore
+
+__attribute__((optnone))
+void testFunction() {}
+
+int main() {
+    int i;
+
+    while(1) {
+        testFunction();
+    }
+}

--- a/selftest/uprobe/test_program/test_program.go
+++ b/selftest/uprobe/test_program/test_program.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+)
+
+//go:noinline
+func testFunction() int {
+	if os.Getenv("SELFTEST_UPROBE_DO_BRANCH") == "y" {
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	for {
+		testFunction()
+	}
+}


### PR DESCRIPTION
This allows users to use the libbpf API for uprobes. This gives you the ability to safely attach to symbols in a userspace binary. 

The API allows users to specify a pid, binary, and symbol name. We could instead have the API allow users to specify specific offsets (instead of symbols) and then make the symbol->offset resolution a public helper function. 

Before we merge this i'd like to verify how architecture specific this is. Right now symbol resolution is handled by parsing ELF binaries. We should think about if there's another object format we should support