### PR TITLE
Change BPFMap method `Update` to unsafe.Pointer

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -472,29 +472,35 @@ func (b *BPFMap) ValueSize() int {
 	return int(C.bpf_map__value_size(b.bpfMap))
 }
 
-func (b *BPFMap) GetValue(key interface{}) ([]byte, error) {
-	keyPtr, err := GetUnsafePointer(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to lookup value in map %s: unknown key type %T", b.name, key)
-	}
-
+// GetValue takes a pointer to the key which is stored in the map.
+// It returns the associated value as a slice of bytes.
+// All basic types, and structs are supported as keys.
+//
+// NOTE: Slices and arrays are also supported but special care
+// should be taken as to take a reference to the first element
+// in the slice or array instead of the slice/array itself, as to
+// avoid undefined behavior.
+func (b *BPFMap) GetValue(key unsafe.Pointer) ([]byte, error) {
 	value := make([]byte, b.ValueSize())
 	valuePtr := unsafe.Pointer(&value[0])
 
-	errC := C.bpf_map_lookup_elem(b.fd, keyPtr, valuePtr)
+	errC := C.bpf_map_lookup_elem(b.fd, key, valuePtr)
 	if errC != 0 {
 		return nil, fmt.Errorf("failed to lookup value %v in map %s", key, b.name)
 	}
 	return value, nil
 }
 
-func (b *BPFMap) DeleteKey(key interface{}) error {
-	keyPtr, err := GetUnsafePointer(key)
-	if err != nil {
-		return fmt.Errorf("failed to update map %s: unknown key type %T", b.name, key)
-	}
-
-	errC := C.bpf_map_delete_elem(b.fd, keyPtr)
+// DeleteKey takes a pointer to the key which is stored in the map.
+// It removes the key and associated value from the BPFMap.
+// All basic types, and structs are supported as keys.
+//
+// NOTE: Slices and arrays are also supported but special care
+// should be taken as to take a reference to the first element
+// in the slice or array instead of the slice/array itself, as to
+// avoid undefined behavior.
+func (b *BPFMap) DeleteKey(key unsafe.Pointer) error {
+	errC := C.bpf_map_delete_elem(b.fd, key)
 	if errC != 0 {
 		return fmt.Errorf("failed to get lookup key %d from map %s", key, b.name)
 	}

--- a/selftest/map-update/go.mod
+++ b/selftest/map-update/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/map-update
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.1.1
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/map-update/go.sum
+++ b/selftest/map-update/go.sum
@@ -1,0 +1,14 @@
+github.com/aquasecurity/libbpfgo v0.1.1 h1:j/ipxI/l20lu5Tosn0o9JYj7bD3Cwzi18jIEEu3rMvQ=
+github.com/aquasecurity/libbpfgo v0.1.1/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -1,0 +1,109 @@
+package main
+
+import "C"
+
+import (
+	"os"
+	"time"
+	"unsafe"
+
+	"encoding/binary"
+	"fmt"
+	"syscall"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func resizeMap(module *bpf.Module, name string, size uint32) error {
+	m, err := module.GetMap("events")
+	if err != nil {
+		return err
+	}
+
+	if err = m.Resize(size); err != nil {
+		return err
+	}
+
+	if actual := m.GetMaxEntries(); actual != size {
+		return fmt.Errorf("map resize failed, expected %v, actual %v", size, actual)
+	}
+
+	return nil
+}
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	bpfModule.BPFLoadObject()
+	prog, err := bpfModule.GetProgram("kprobe__sys_mmap")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	testerMap, err := bpfModule.GetMap("tester")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	key1 := uint32(1)
+	value1 := struct{ x int }{50}
+	key1Unsafe := unsafe.Pointer(&key1)
+	value1Unsafe := unsafe.Pointer(&value1)
+	testerMap.Update(key1Unsafe, value1Unsafe)
+
+	key2 := int64(42069420)
+	value2 := []byte{'a', 'b', 'c'}
+	key2Unsafe := unsafe.Pointer(&key2)
+	value2Unsafe := unsafe.Pointer(&value2[0])
+	testerMap.Update(key2Unsafe, value2Unsafe)
+
+	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	eventsChannel := make(chan []byte)
+	lostChannel := make(chan uint64)
+	pb, err := bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	pb.Start()
+
+	go func() {
+		time.Sleep(time.Second)
+		syscall.Mmap(999, 999, 999, 1, 1)
+		syscall.Mmap(999, 999, 999, 1, 1)
+	}()
+
+	ev := <-eventsChannel
+	if binary.LittleEndian.Uint32(ev) != 50 {
+		fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+		os.Exit(-1)
+	}
+
+	ev = <-eventsChannel
+	if ev[0] != value2[0] || ev[1] != value2[1] || ev[2] != value2[2] {
+		fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+		os.Exit(-1)
+	}
+
+	pb.Stop()
+	pb.Close()
+}

--- a/selftest/map-update/self.bpf.c
+++ b/selftest/map-update/self.bpf.c
@@ -1,0 +1,43 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct value {
+    int x;
+    char y;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, struct value);
+    __uint(max_entries, 1<<24);
+} tester SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    u32 firstKey = 1;
+    struct value *v1 = bpf_map_lookup_elem(&tester, &firstKey);
+    if (!v1) {
+        return 1;
+    }
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v1, sizeof(struct value));
+
+    int64_t secondKey = 42069420;
+    struct value *v2 = bpf_map_lookup_elem(&tester, &secondKey);
+    if (!v2) {
+        return 1;
+    }
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v2, sizeof(char)*3);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
This makes a breaking change to the libbpfgo API in which
the BPFMap.Update() method takes two unsafe.Pointer instead
of two interface{}. This is so that libbpfgo does not have
to know or care about the type of the passed value. If bpf
and libbpf can support the datatype, so should libbpfgo.

It's important to note that it would then be on the user to
correctly pass arrays/slices (reference must be passed to the
first element, not the array/slice itself).

This also adds a selftest but I haven't added it to any build
script/Makefile, as I'm waiting for #28 to merge, then I will
rebase and update accordingly. 

We should heavily consider the implications of this breaking
API change.

cc @derekparker 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>