### PR TITLE
New helper (getter) functions and some refactoring

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -378,11 +378,8 @@ func (m *Module) GetMap(mapName string) (*BPFMap, error) {
 }
 
 func (b *BPFMap) Pin(pinPath string) error {
-	cs := C.CString(b.name)
 	path := C.CString(pinPath)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	errC := C.bpf_map__pin(bpfMap, path)
-	C.free(unsafe.Pointer(cs))
+	errC := C.bpf_map__pin(b.bpfMap, path)
 	if errC != 0 {
 		return fmt.Errorf("failed to pin map %s to path %s", b.name, pinPath)
 	}
@@ -390,11 +387,8 @@ func (b *BPFMap) Pin(pinPath string) error {
 }
 
 func (b *BPFMap) Unpin(pinPath string) error {
-	cs := C.CString(b.name)
 	path := C.CString(pinPath)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	errC := C.bpf_map__unpin(bpfMap, path)
-	C.free(unsafe.Pointer(cs))
+	errC := C.bpf_map__unpin(b.bpfMap, path)
 	if errC != 0 {
 		return fmt.Errorf("failed to unpin map %s from path %s", b.name, pinPath)
 	}
@@ -402,11 +396,8 @@ func (b *BPFMap) Unpin(pinPath string) error {
 }
 
 func (b *BPFMap) SetPinPath(pinPath string) error {
-	cs := C.CString(b.name)
 	path := C.CString(pinPath)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	errC := C.bpf_map__set_pin_path(bpfMap, path)
-	C.free(unsafe.Pointer(cs))
+	errC := C.bpf_map__set_pin_path(b.bpfMap, path)
 	if errC != 0 {
 		return fmt.Errorf("failed to set pin for map %s to path %s", b.name, pinPath)
 	}
@@ -419,10 +410,7 @@ func (b *BPFMap) SetPinPath(pinPath string) error {
 // Note: for ring buffer and perf buffer, maxEntries is the
 // capacity in bytes.
 func (b *BPFMap) Resize(maxEntries uint32) error {
-	cs := C.CString(b.name)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	errC := C.bpf_map__resize(bpfMap, C.uint(maxEntries))
-	C.free(unsafe.Pointer(cs))
+	errC := C.bpf_map__resize(b.bpfMap, C.uint(maxEntries))
 	if errC != 0 {
 		return fmt.Errorf("failed to resize map %s to %v", b.name, maxEntries)
 	}
@@ -433,10 +421,7 @@ func (b *BPFMap) Resize(maxEntries uint32) error {
 // Note: for ring buffer and perf buffer, maxEntries is the
 // capacity in bytes.
 func (b *BPFMap) GetMaxEntries() uint32 {
-	cs := C.CString(b.name)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	maxEntries := C.bpf_map__max_entries(bpfMap)
-	C.free(unsafe.Pointer(cs))
+	maxEntries := C.bpf_map__max_entries(b.bpfMap)
 	return uint32(maxEntries)
 }
 
@@ -453,18 +438,12 @@ func (b *BPFMap) GetModule() *Module {
 }
 
 func (b *BPFMap) GetPinPath() string {
-	cs := C.CString(b.name)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	pinPathGo := C.GoString(C.bpf_map__get_pin_path(bpfMap))
-	C.free(unsafe.Pointer(cs))
+	pinPathGo := C.GoString(C.bpf_map__get_pin_path(b.bpfMap))
 	return pinPathGo
 }
 
 func (b *BPFMap) IsPinned() bool {
-	cs := C.CString(b.name)
-	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
-	isPinned := C.bpf_map__is_pinned(bpfMap)
-	C.free(unsafe.Pointer(cs))
+	isPinned := C.bpf_map__is_pinned(b.bpfMap)
 	if isPinned == C.bool(true) {
 		return true
 	}

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -448,6 +448,10 @@ func (b *BPFMap) GetName() string {
 	return b.name
 }
 
+func (b *BPFMap) GetModule() *Module {
+	return b.module
+}
+
 func (b *BPFMap) GetPinPath() string {
 	cs := C.CString(b.name)
 	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
@@ -628,6 +632,10 @@ func (m *Module) GetProgram(progName string) (*BPFProg, error) {
 
 func (p *BPFProg) GetFd() C.int {
 	return C.bpf_program__fd(p.prog)
+}
+
+func (p *BPFProg) GetModule() *Module {
+	return p.module
 }
 
 func (p *BPFProg) GetName() string {

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -440,6 +440,33 @@ func (b *BPFMap) GetMaxEntries() uint32 {
 	return uint32(maxEntries)
 }
 
+func (b *BPFMap) GetFd() int {
+	return int(b.fd)
+}
+
+func (b *BPFMap) GetName() string {
+	return b.name
+}
+
+func (b *BPFMap) GetPinPath() string {
+	cs := C.CString(b.name)
+	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
+	pinPathGo := C.GoString(C.bpf_map__get_pin_path(bpfMap))
+	C.free(unsafe.Pointer(cs))
+	return pinPathGo
+}
+
+func (b *BPFMap) IsPinned() bool {
+	cs := C.CString(b.name)
+	bpfMap := C.bpf_object__find_map_by_name(b.module.obj, cs)
+	isPinned := C.bpf_map__is_pinned(bpfMap)
+	C.free(unsafe.Pointer(cs))
+	if isPinned == C.bool(true) {
+		return true
+	}
+	return false
+}
+
 func GetUnsafePointer(data interface{}) (unsafe.Pointer, error) {
 	var dataPtr unsafe.Pointer
 	switch k := data.(type) {
@@ -601,6 +628,10 @@ func (m *Module) GetProgram(progName string) (*BPFProg, error) {
 
 func (p *BPFProg) GetFd() C.int {
 	return C.bpf_program__fd(p.prog)
+}
+
+func (p *BPFProg) GetName() string {
+	return p.name
 }
 
 // BPFProgType is an enum as defined in https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/bpf.h

--- a/selftest/map-pin-info/Makefile
+++ b/selftest/map-pin-info/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/map-pin-info/go.mod
+++ b/selftest/map-pin-info/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/map-pin-info
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.1.1
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/map-pin-info/go.sum
+++ b/selftest/map-pin-info/go.sum
@@ -1,0 +1,14 @@
+github.com/aquasecurity/libbpfgo v0.1.1 h1:j/ipxI/l20lu5Tosn0o9JYj7bD3Cwzi18jIEEu3rMvQ=
+github.com/aquasecurity/libbpfgo v0.1.1/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/map-pin-info/main.bpf.c
+++ b/selftest/map-pin-info/main.bpf.c
@@ -1,0 +1,25 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct value {
+	int x;
+	char y;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct value);
+	__uint(max_entries, 1<<10);
+} not_pinned_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct value);
+	__uint(max_entries, 1<<10);	
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} pinned_map SEC(".maps");
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-pin-info/main.go
+++ b/selftest/map-pin-info/main.go
@@ -1,0 +1,76 @@
+package main
+
+import "C"
+
+import (
+	"fmt"
+	"os"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func getSupposedPinPath(m *bpf.BPFMap) string {
+	return "/sys/fs/bpf/" + m.GetName()
+}
+
+func main() {
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	bpfModule.BPFLoadObject()
+
+	pinnedMap, err := bpfModule.GetMap("pinned_map")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	var supposedPinPath = getSupposedPinPath(pinnedMap)
+	var actualPinPath string
+
+	defer pinnedMap.Unpin(supposedPinPath)
+
+	if !pinnedMap.IsPinned() {
+		fmt.Fprintf(os.Stderr,
+			"IsPinned() returned 'false' when map %s should be pinned\n",
+			pinnedMap.GetName())
+		os.Exit(-1)
+	}
+
+	actualPinPath = pinnedMap.GetPinPath()
+	if actualPinPath != supposedPinPath {
+		fmt.Fprintf(os.Stderr,
+			"GetPinPath() returned %s when should be %s\n",
+			actualPinPath, supposedPinPath)
+		os.Exit(-1)
+	}
+
+	notPinnedMap, err := bpfModule.GetMap("not_pinned_map")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	if notPinnedMap.IsPinned() {
+		fmt.Fprintf(os.Stderr,
+			"IsPinned() returned 'true' when map %s should not be pinned\n",
+			pinnedMap.GetName())
+		os.Exit(-1)
+	}
+
+	supposedPinPath = getSupposedPinPath(notPinnedMap)
+
+	notPinnedMap.Pin(supposedPinPath)
+	defer notPinnedMap.Unpin(supposedPinPath)
+
+	actualPinPath = notPinnedMap.GetPinPath()
+	if actualPinPath != supposedPinPath {
+		fmt.Fprintf(os.Stderr,
+			"GetPinPath() returned %s when should be %s\n",
+			actualPinPath, supposedPinPath)
+		os.Exit(-1)
+	}
+}

--- a/selftest/map-pin-info/run.sh
+++ b/selftest/map-pin-info/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh


### PR DESCRIPTION
This originated from Discussion https://github.com/aquasecurity/libbpfgo/discussions/40

It adds the following functions.

For BPFMap:

```go
GetFd()
GetName()
GetPinPath()
IsPinned()
GetModule()
```

For BPFProg:

```go
GetName()
GetModule()
```

It also does some refactoring to make reuse of the already got libbpf map pointer: `bpfMap *C.struct_bpf_map`.