### PR TITLE
examples: Add tcpconnect as a libbpfgo example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 output*
-selftest/*/main
 selftest/*/*.o
+selftest/*/*.skel.h
 selftest/*/*-static
 selftest/*/*-dynamic
 selftest/uprobe/ctest

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test: libbpfgo-dynamic-test
 
 # libbpfgo test object
 
-libbpfgo-test-bpf-static: libbpfgo-static		# needed for serialization
+libbpfgo-test-bpf-static: libbpfgo-static	# needed for serialization
 	$(MAKE) -C $(SELFTEST)/build
 
 libbpfgo-test-bpf-dynamic: libbpfgo-dynamic	# needed for serialization
@@ -99,6 +99,9 @@ $(VMLINUXH): $(OUTPUT)
 	fi
 
 # static libbpf generation for the git submodule
+
+.PHONY: libbpf-static
+libbpf-static: $(LIBBPF_OBJ)
 
 $(LIBBPF_OBJ): $(LIBBPF_SRC) $(wildcard $(LIBBPF_SRC)/*.[ch]) | $(OUTPUT)/libbpf
 	CC="$(CC)" CFLAGS="$(CFLAGS)" LD_FLAGS="$(LDFLAGS)" \

--- a/selftest/common/common.sh
+++ b/selftest/common/common.sh
@@ -107,6 +107,7 @@ execbg() {
 }
 
 waitbg() {
+  echo "waiting for background tasks"
   sleep $_bigtimeout
 }
 

--- a/selftest/tcpconnect/Makefile
+++ b/selftest/tcpconnect/Makefile
@@ -1,0 +1,124 @@
+BASEDIR = $(abspath ../../)
+
+OUTPUT = ../../output
+
+LIBBPF_SRC = $(abspath ../../libbpf/src)
+LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
+
+CC = gcc
+CLANG = clang
+
+ARCH = x86
+GOARCH = amd64
+
+BPFTOOL = $(shell which bpftool || /bin/false)
+
+CFLAGS = -g -O2 -Wall -fpie -Wno-unused-variable -Wno-unused-function
+LDFLAGS =
+
+CGO_CFLAGS_STATIC = "-I$(abspath $(OUTPUT))"
+CGO_LDFLAGS_STATIC = "-lelf -lz $(LIBBPF_OBJ)"
+CGO_EXTLDFLAGS_STATIC = '-w -extldflags "-static"'
+
+CGO_CFGLAGS_DYN = "-I. -I/usr/include/"
+CGO_LDFLAGS_DYN = "-lelf -lz -lbpf"
+
+.PHONY: $(TEST)
+.PHONY: $(TEST).go
+.PHONY: $(TEST).bpf.c
+.PHONY: tcpclient tcpserver
+
+TEST = main
+
+all:
+	$(MAKE) -C . $(TEST)-dynamic
+	$(MAKE) -C . $(TEST)-static
+	$(MAKE) -C . $(TEST)-c-dynamic
+	$(MAKE) -C . $(TEST)-c-static
+
+.PHONY: libbpfgo
+.PHONY: libbpfgo-static
+.PHONY: libbpfgo-dynamic
+
+## libbpfgo
+
+libbpfgo-static:
+	$(MAKE) -C $(BASEDIR) libbpfgo-static
+
+libbpfgo-dynamic:
+	$(MAKE) -C $(BASEDIR) libbpfgo-dynamic
+
+vmlinuxh:
+	$(MAKE) -C $(BASEDIR) vmlinuxh
+
+outputdir:
+	$(MAKE) -C $(BASEDIR) outputdir
+
+## test bpf dependency
+
+$(TEST).bpf.o: $(TEST).bpf.c
+	$(MAKE) -C $(BASEDIR) vmlinuxh
+	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH) -I$(OUTPUT) -c $< -o $@
+
+## test
+
+.PHONY: $(TEST)-static
+.PHONY: $(TEST)-dynamic
+
+$(TEST)-static: libbpfgo-static | $(TEST).bpf.o
+	CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
+		GOARCH=$(GOARCH) \
+		go build \
+		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
+		-o $(TEST)-static ./$(TEST).go
+
+$(TEST)-dynamic: libbpfgo-dynamic | $(TEST).bpf.o
+	CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
+		go build -o ./$(TEST)-dynamic ./$(TEST).go
+
+## clean
+
+clean:
+	rm -f *.o *-static *-dynamic *.skel.h
+
+## c example (extra, no need for libbpfgo only project)
+
+.PHONY: $(TEST).c
+
+$(TEST).skel.h: $(TEST).bpf.o
+	$(BPFTOOL) gen skeleton $< > $@
+
+.PHONY: $(TEST)-c-static
+.PHONY: $(TEST)-c-dynamic
+
+libbpf-static:
+	$(MAKE) -C $(BASEDIR) libbpf-static
+
+# static here means libbpf statically compiled only
+# go example is generating full static binaries
+
+$(TEST)-c-static: libbpf-static | $(TEST).skel.h
+	$(CLANG) $(CGO_CFLAGS_STATIC) -lelf -lz -I$(OUTPUT) $(TEST).c -o $@ $(LIBBPF_OBJ)
+
+$(TEST)-c-dynamic: $(TEST).skel.h
+	$(CLANG) $(CGO_CFLAGS_STATIC) -lelf -lz -lbpf -I$(OUTPUT) $(TEST).c -o $@
+
+## run
+
+.PHONY: run
+.PHONY: run-static
+.PHONY: run-dynamic
+
+run: run-static
+
+run-static: $(TEST)-static | $(TEST)-c-static
+	sudo ./run.sh $(TEST)-static
+	sudo ./run.sh $(TEST)-c-static
+
+run-dynamic: $(TEST)-dynamic | $(TEST)-c-dynamic
+	sudo ./run.sh $(TEST)-dynamic
+	sudo ./run.sh $(TEST)-c-dynamic

--- a/selftest/tcpconnect/README.md
+++ b/selftest/tcpconnect/README.md
@@ -1,0 +1,281 @@
+## libbpfgo: tcpconnect example
+
+### Introduction
+
+The idea behind this test directory is to document how you can migrate from a C eBPF based code, using [libbpf](https://github.com/libbpf/libbpf), to a pure golang eBPF code, using [libbpfgo](https://github.com/aquasecurity/libbpfgo). You may also read the Makefile to better understand how to build static and dynamic Go binaries with [libbpfgo](https://github.com/aquasecurity/libbpfgo).
+
+The directory structure is this:
+
+* main.bpf.o: the eBPF program loaded to the kernel
+* main.go: the Go version of the userland program
+* main.c: the C version of the userland progam
+
+Both main.go and main.c programs should behave similarly, if not identically.
+
+There are better places to learn eBPF, like:
+
+1. https://ebpf.io/what-is-ebpf
+1. https://ebpf.io/what-is-ebpf#introduction-to-ebpf
+1. https://ebpf.io/what-is-ebpf#maps
+1. https://ebpf.io/what-is-ebpf#why-ebpf
+1. https://facebookmicrosites.github.io/bpf/blog/2020/02/19/bpf-portability-and-co-re.html
+1. https://facebookmicrosites.github.io/bpf/blog/2020/02/20/bcc-to-libbpf-howto-guide.html
+
+This Readme file will quickly explain how this test works, so it can serve you as a reference for building a new test, or a new [libbpfgo](https://github.com/aquasecurity/libbpfgo) application.
+
+The main eBPF structures to have in mind are:
+
+* `bpf object` will contain bpf_programs and bpf_maps and more.
+* `bpf program` is one non inline function from `main.bpf.c`.
+* `bpf map` is a data structure shared between eBPF programs and userland.
+
+### main.bpf.c
+
+This is the file that will be compiled into eBPF binary object and loaded into the kernel for its eBPF JIT compiler to transform it to the current running architecture. The eBPF byte code contains different "programs", one per non-inline function, and each will run triggered by different events within the kernel.
+
+The eBPF programs running inside the kernel may extract information - or, sometimes, take actions - and submit to userland through the use shared structures called [eBPF MAPS](https://ebpf.io/what-is-ebpf#map).
+
+In this test example, the structure used for this communication to happen is the one below.
+
+```C
+struct data_t {
+        char comm[16];          // command (task_comm_len)
+        u32  pid;               // proccess id
+        u32  uid;               // user id
+        u32  gid;               // group id
+        u32  loginuid;          // real user (login/terminal)
+        u8   family;            // network family
+        u8   proto;             // protocol (sock.h: u8 older, u16 newer)
+        u16  sport;             // source port
+        u16  dport;             // destination port
+        u32  saddr;             // source address
+        struct in6_addr saddr6; // source address (IPv6)
+        u32  daddr;             // destination address
+        struct in6_addr daddr6; // destination address (IPv6)
+        u8   thesource;         // I am the one originating packet
+};
+```
+
+This means that both, the eBPF program, and the userland code, need to know about this structure, so they can communicate.
+
+> Note: there are different types of events which an eBPF program can be attached to (links) and different types of maps that can be used to exchange data. I'm not entering that topic here and this example uses simple ones.
+
+From the snippet below:
+
+```C
+SEC("kprobe/tcp_connect")
+int BPF_KPROBE(tcp_connect, struct sock *sk)
+{
+	return tcp_connect_enter(ctx, sk);
+}
+```
+
+We are creating an eBPF program of name **tcp_connect**, it will be of type **kprobe** and will be linked to the kernel function **tcp_connect** (its event). Each time the probe is triggered, it calls an inline function passing the function arguments.
+
+In the inline function:
+
+```C
+static __always_inline int
+tcp_connect_enter(struct pt_regs *ctx, struct sock *sk)
+{
+    ...
+	bpf_probe_read_kernel(&data.family, sizeof(u8), &sk->__sk_common.skc_family);
+	...
+
+	return bpf_perf_event_output(ctx, &events, 0xffffffffULL, &data, sizeof(data));
+}
+```
+
+We read things from the kernel and share with userland through a simple eBPF array map called 'perf event array':
+
+> Note: Like said previously, eBPF maps are data structures, of different kind/type, existing in kernel and accessible from eBPF programs and userland.
+
+```C
+`struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps")
+```
+
+Now, to the userland code...
+
+## main.c
+
+Through the direct usage of [libbpf](https://github.com/libbpf/libbpf), the main.c code will consume the perf events described in previous session. 
+
+Initially [libbpf](https://github.com/libbpf/libbpf) library has to:
+
+1. deal with embedded bytecode of eBPF programs (if using skeleton)
+1. load eBPF object into the kernel (containing 1 or more programs)
+1. create 1 link per existing eBPF program (program <-> kernel event)
+1. create in-kernel eBPF maps based in the eBPF object 
+1. run the userland portion of your program
+
+This is done by the following calls:
+
+```C
+if ((err = bump_memlock_rlimit()))
+    exiterr("failed to increase rlimit: %d", err);
+
+if ((pid_max = get_pid_max()) < 0)
+    exiterr("failed to get pid_max");
+
+// create BPF module using BPF object file
+if (!(main = main_bpf__open()))
+    exiterr("failed to open BPF object");
+
+// load BPF object from BPF module
+if ((err = main_bpf__load(main)))
+    exiterr("failed to load BPF object: %d\n", err);
+
+// attach to BPF program to kprobe
+if ((err = main_bpf__attach(main)))
+    exiterr("failed to attach\n");
+```
+
+> **Note**: This example has only 1 eBPF program called `tcp_connect`, linked to a `kprobe` event attached to the kernel function `tcp_connect`.
+ 
+The [libbpf](https://github.com/libbpf/libbpf) library has the concept of [eBPF skeleton](https://lwn.net/Articles/806911/). It will load all your programs and create all your maps automatically with single calls to the library. If you prefer, you may also specificy the eBPF programs (from `main.bpf.c`) you would like to load and which maps to create, one by one.
+
+After initialization, it is time to configure a perf event polling logic:
+
+```C
+pb_opts.sample_cb = handle_event;
+pb_opts.lost_cb = handle_lost_events;
+
+pb = perf_buffer__new(bpf_map__fd(main->maps.events), 16, &pb_opts);
+
+while (1) {
+
+    if ((err = perf_buffer__poll(pb, 100)) < 0) {
+        err = 1; // real error
+        goto cleanup;
+    }
+    ...
+```
+
+This is similar to any other select()/poll() logic. The poll waits for the eBPF map (**events**) event to happen through the map fd and calls the callback function.
+
+Callback function deals with the data sent through eBPF map (**events**) in **data_t** format, showing information caught from the kernel.
+
+So, for the **tcpconnect** example, every time `main.bpf.c` **tcp_connect_enter()** function submits a perf event, because the kprobe **tcp_connect** was triggered, the userland code receives the event data (struct data_t format) through shared perf event array eBPF map **events**.
+
+The callback will then handle the received - from eBPF program - data:
+
+```C
+static int output(struct data_t *e)
+{
+	struct in_addr src, dst;
+	u16 sport = htons(e->sport);
+	u16 dport = htons(e->dport);
+	char *src_str = NULL, *dst_str = NULL;
+
+	src.s_addr = e->saddr; // e->saddr comes from eBPF
+	dst.s_addr = e->daddr; // e->daddr comes from eBPF
+
+	switch (e->family) {   // e->family comes from eBPF
+		case AF_INET:
+			src_str = ipv4_str(&src);
+			dst_str = ipv4_str(&dst);
+			break;
+		default:
+			return 0;
+	}
+	...
+```
+
+### main.go
+
+Now that you know how an eBPF program works, and how the userland code made with [libbpf](https://github.com/libbpf/libbpf) works, it is time to show how to make the same program using [libbpfgo](https://github.com/aquasecurity/libbpfgo).
+
+With [libbpfgo](https://github.com/aquasecurity/libbpfgo) we have 1 main object, the **BPF Module**, and other objects representing data structures from [libbpf](https://github.com/libbpf/libbpf), being the most important ones:
+
+```go
+    var bpfModule *bpf.Module       // wrapper for the bpf_object structure
+    var bpfMapEvents *bpf.BPFMap    // wrapper for the bpf_maps structure
+    var bpfProg *bpf.BPFProg        // wrapper for the bpf_program structure
+```
+
+Being a wrapper to [libbpf](https://github.com/libbpf/libbpf), it is expected [libbpfgo](https://github.com/aquasecurity/libbpfgo) initialization to be similar to the C code:
+
+```go
+	// create BPF module using BPF object file
+	bpfModule, erro = bpf.NewModuleFromFile("main.bpf.o")
+	
+	defer bpfModule.Close()
+
+	// BPF map "events": resize it before object is loaded
+	bpfMapEvents, erro = bpfModule.GetMap("events")
+	
+	erro = bpfMapEvents.Resize(8192)
+
+	// load BPF object from BPF module
+	bpfModule.BPFLoadObject();
+
+	// get BPF program from BPF object
+	bpfProgTcpConnect, erro = bpfModule.GetProgram("tcp_connect")
+
+	// attach to BPF program to kprobe
+	_, erro = bpfProgTcpConnect.AttachKprobe("tcp_connect")
+```
+
+Like said earlier, by using [libbpf](https://github.com/libbpf/libbpf) you can either use skeleton OR provide each eBPF object, program and map to be created and loaded, like [libbpfgo](https://github.com/aquasecurity/libbpfgo) does.
+
+This code snippet:
+
+1. creates an eBPF module **bpfModule** and defers its closure
+1. creates **bpfMapEvents** map object from the already created **events** map
+1. loads **main.bpf.o** (eBPF compiled) object into kernel and all its programs
+1. new **bpfProgramTcpConnect** is created from **tcp_connect** eBPF program
+1. **bpfProgramTcpConnect** is attached to **tcp_connect** kprobe event 
+1. attachment creates a BPFlink (not being used in this example).
+
+After initialization, it is time to do what Go does best: event oriented work:
+
+```Go
+// channel for events (and lost events)
+eventsChannel = make(chan []byte)
+lostChannel = make(chan uint64)
+
+perfBuffer, err = bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)
+
+// start perf event polling (will receive events through eventChannel)
+perfBuffer.Start()
+```
+
+Easier than the [libbpf](https://github.com/libbpf/libbpf) C version, with [libbpfgo](https://github.com/aquasecurity/libbpfgo) the polling logic is hidden. We simply create a **perfBuffer** object from **bpfModule**, for a specific map **events**, and specify which channels should be used for events or lost events:
+
+```go
+
+for dataRaw := range eventsChannel {
+	var dt data
+	var dataBuffer *bytes.Buffer
+
+	dataBuffer = bytes.NewBuffer(dataRaw)
+
+	err = binary.Read(dataBuffer, binary.LittleEndian, &dt)
+	if err != nil {
+		fmt.Println(err)
+		continue
+	}
+
+	var bsport = make([]byte, 2)
+	var bdport = make([]byte, 2)
+	binary.BigEndian.PutUint16(bsport, dt.SPort)
+	binary.BigEndian.PutUint16(bdport, dt.DPort)
+
+	godata := gdata{
+		Comm:     string(bytes.TrimRight(dt.Comm[:], "\x00")),
+		Pid:      uint(dt.Pid),
+		Uid:      uint(dt.Uid),
+		Gid:      uint(dt.Gid),
+		LoginUid: uint(dt.LoginUid),
+		Family:   uint(dt.Family),
+		Proto:    uint(dt.Proto),
+		SPort:    uint(binary.LittleEndian.Uint16(bsport)),
+		DPort:    uint(binary.LittleEndian.Uint16(bdport)),
+	}
+```
+
+> **Note**: because [libbpfgo](https://github.com/aquasecurity/libbpfgo) uses #cgo, it is mandatory that you convert the "struct data_t", coming from the events channel, to a go struct (using go primitives)

--- a/selftest/tcpconnect/go.mod
+++ b/selftest/tcpconnect/go.mod
@@ -1,0 +1,7 @@
+module tcpconnect
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.1.1
+
+//replace github.com/aquasecurity/libbpfgo => ../../ebpf/libbpfgo/

--- a/selftest/tcpconnect/go.sum
+++ b/selftest/tcpconnect/go.sum
@@ -1,0 +1,11 @@
+github.com/aquasecurity/libbpfgo v0.1.1 h1:j/ipxI/l20lu5Tosn0o9JYj7bD3Cwzi18jIEEu3rMvQ=
+github.com/aquasecurity/libbpfgo v0.1.1/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/tcpconnect/main.bpf.c
+++ b/selftest/tcpconnect/main.bpf.c
@@ -1,0 +1,196 @@
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+//#include <arpa/inet.h>
+//#include <netinet/in.h>
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct data_t {
+        char comm[16];          // command (task_comm_len)
+        u32  pid;               // proccess id
+        u32  uid;               // user id
+        u32  gid;               // group id
+        u32  loginuid;          // real user (login/terminal)
+        u8   family;            // network family
+        u8   proto;             // protocol (sock.h: u8 older, u16 newer)
+        u16  sport;             // source port
+        u16  dport;             // destination port
+        u32  saddr;             // source address
+        struct in6_addr saddr6; // source address (IPv6)
+        u32  daddr;             // destination address
+        struct in6_addr daddr6; // destination address (IPv6)
+        u8   thesource;         // I am the one originating packet
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+/*
+ * NOTE: keeping this, for now, compatible to v4.15 kernels, that is why it
+ * does not have all ebpf latest features
+ */
+
+#define BASE \
+	struct data_t data = {};					\
+	struct task_struct *task = (void *) bpf_get_current_task();	\
+	u64 id1 = bpf_get_current_pid_tgid(); 				\
+	u64 id2 = bpf_get_current_uid_gid(); 				\
+	u32 tgid = id1 >> 32, pid = id1; 				\
+	u32 gid = id2 >> 32, uid = id2; 				\
+	data.pid = tgid;						\
+	data.uid = uid;							\
+	data.uid = gid;							\
+	bpf_probe_read_kernel(&data.loginuid, sizeof(unsigned int), &task->loginuid.val); \
+	bpf_probe_read_kernel_str(&data.comm, 16, task->comm);
+
+#define COMMON \
+	BASE								\
+	struct inet_sock *inet = inet_sk(sk);				\
+	struct tcp_sock *tp = tcp_sk(sk);				\
+	struct flowi4 *fl4= &inet->cork.fl.u.ip4;			\
+	struct flowi6 *fl6= &inet->cork.fl.u.ip6;			\
+	struct ipv6_pinfo *np = inet6_sk(sk);				\
+
+#undef htons
+#define htons(x) ((__be16)(__u16)(x))
+
+static __always_inline bool
+check_for_zeros_v4(struct data_t *gdata)
+{
+	if (gdata->sport == 0 || gdata->dport == 0)
+		return 1;
+	if (gdata->saddr == 0 || gdata->daddr == 0)
+		return 1;
+
+	return 0;
+}
+
+static __always_inline bool
+check_for_zeros_v6(struct data_t *gdata)
+{
+	if (gdata->sport == 0 || gdata->dport == 0)
+		return 1;
+
+	if (gdata->saddr6.in6_u.u6_addr32[0] == 0xFFFF || gdata->daddr6.in6_u.u6_addr32[0] == 0xFFFF)
+		return 1;
+
+	return 0;
+}
+
+static __always_inline struct inet_sock *
+inet_sk(const struct sock *sk)
+{
+	struct inet_sock *ptr;
+
+	bpf_probe_read_kernel(&ptr, sizeof (void *), &sk);
+
+	return ptr;
+}
+
+static __always_inline struct tcp_sock *
+tcp_sk(const struct sock *sk)
+{
+	return (struct tcp_sock *)sk;
+}
+
+static __always_inline struct ipv6_pinfo *
+inet6_sk(const struct sock *__sk)
+{
+	struct inet_sock *inet = inet_sk(__sk);
+	struct ipv6_pinfo *ptr;
+
+	bpf_probe_read_kernel(&ptr, sizeof(void *), &inet->pinet6);
+
+	return ptr;
+}
+
+static inline unsigned char *
+skb_transport_header(const struct sk_buff *skb)
+{
+	u16 transp_header;
+	unsigned char *head;
+
+	bpf_probe_read_kernel(&head, sizeof(void *), &skb->head);
+	bpf_probe_read_kernel(&transp_header, sizeof(u16), &skb->transport_header);
+
+	return head + transp_header;
+}
+
+static inline unsigned char *
+skb_network_header(const struct sk_buff *skb)
+{
+	u16 net_header;
+	unsigned char *head;
+
+	bpf_probe_read_kernel(&head, sizeof(void *), &skb->head);
+	bpf_probe_read_kernel(&net_header, sizeof(u16), &skb->network_header);
+
+	return head + net_header;
+}
+
+static inline struct iphdr *ip_hdr(const struct sk_buff *skb)
+{
+	return (struct iphdr *)skb_network_header(skb);
+}
+
+static inline struct ipv6hdr *ipv6_hdr(const struct sk_buff *skb)
+{
+	return (struct ipv6hdr *)skb_network_header(skb);
+}
+
+// TCPv4/TCPv6 outbound: probe compatible to v4.15 and v5.8
+
+static __always_inline int
+tcp_connect_enter(struct pt_regs *ctx, struct sock *sk)
+{
+	COMMON;
+
+	volatile u8 skc_state;	// sk_type is bitfield, guess if this is UDP or TCP
+
+	bpf_probe_read_kernel((u8 *) &skc_state, sizeof(u8), (u8 *) &sk->__sk_common.skc_state);
+	if (skc_state != 2)	// TCP_SYN_SENT
+		return 0;
+
+	data.thesource = 1;	// OUTBOUND
+	data.proto = 6;		// IPPROTO_TCP
+
+	bpf_probe_read_kernel(&data.family, sizeof(u8), &sk->__sk_common.skc_family);
+
+	switch (data.family) {
+	case 2: // AF_INET
+		bpf_probe_read_kernel(&data.saddr, sizeof(u32), &sk->__sk_common.skc_rcv_saddr);
+		bpf_probe_read_kernel(&data.daddr, sizeof(u32), &sk->__sk_common.skc_daddr);
+		bpf_probe_read_kernel(&data.sport, sizeof(u16), &inet->inet_sport);
+		bpf_probe_read_kernel(&data.dport, sizeof(u16), &sk->__sk_common.skc_dport);
+		if (check_for_zeros_v4(&data))
+			return 0;
+		break;
+	case 10: // AF_INET6
+		bpf_probe_read_kernel(&data.saddr6, sizeof(data.saddr6), &sk->__sk_common.skc_v6_rcv_saddr);
+		bpf_probe_read_kernel(&data.daddr6, sizeof(data.daddr6), &sk->__sk_common.skc_v6_daddr);
+		bpf_probe_read_kernel(&data.sport, sizeof(u16), &inet->inet_sport);
+		bpf_probe_read_kernel(&data.dport, sizeof(u16), &sk->__sk_common.skc_dport);
+		if (check_for_zeros_v6(&data))
+			return 0;
+		break;
+	}
+
+	return bpf_perf_event_output(ctx, &events, 0xffffffffULL, &data, sizeof(data));
+}
+
+SEC("kprobe/tcp_connect")
+int BPF_KPROBE(tcp_connect, struct sock *sk)
+{
+	return tcp_connect_enter(ctx, sk);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/selftest/tcpconnect/main.c
+++ b/selftest/tcpconnect/main.c
@@ -1,0 +1,279 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <signal.h>
+#include <getopt.h>
+#include <unistd.h>
+#include <time.h>
+#include <pwd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <linux/perf_event.h>
+#include <linux/hw_breakpoint.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+
+#include "main.skel.h"
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+#define _wrapout(nl, ...)               \
+{                                       \
+        fprintf(stdout, __VA_ARGS__);   \
+        if (nl)                         \
+        fprintf(stdout, "\n");          \
+}
+
+#define _wrapout0(...) _wrapout(0, __VA_ARGS__)
+#define _wrapout1(...) _wrapout(1, __VA_ARGS__)
+
+#define wrapout  _wrapout1
+#define here     _wrapout1("line %d, file %s, function %s", __LINE__, __FILE__, __func__)
+#define debug(a) _wrapout1("%s (line %d, file %s, function %s)", a, __LINE__, __FILE__, __func__)
+
+#define exiterr(...)            \
+{                               \
+        here;                   \
+        exit(1);                \
+}
+
+struct data_t {
+	char comm[16];          // command (task_comm_len)
+	u32  pid;               // proccess id
+	u32  uid;               // user id
+	u32  gid;               // group id
+	u32  loginuid;          // real user (login/terminal)
+	u8   family;            // network family
+	u8   proto;             // protocol (sock.h: u8 older, u16 newer)
+	u16  sport;             // source port
+	u16  dport;             // destination port
+	u32  saddr;             // source address
+	struct in6_addr saddr6; // source address (IPv6)
+	u32  daddr;             // destination address
+	struct in6_addr daddr6; // destination address (IPv6)
+	u8   thesource;         // I am the one originating packet
+};
+
+static int bpfverbose = 0;
+static volatile bool exiting;
+static volatile bool found;
+
+static int get_pid_max(void)
+{
+	FILE *f;
+	int pid_max = 0;
+
+	if ((f = fopen("/proc/sys/kernel/pid_max", "r")) == NULL)
+		exiterr("failed to open proc_sys pid_max");
+
+	if (fscanf(f, "%d\n", &pid_max) != 1)
+		exiterr("failed to read proc_sys pid_max");
+
+	fclose(f);
+
+	return pid_max;
+}
+
+int bump_memlock_rlimit(void)
+{
+	struct rlimit rlim_new = {
+		.rlim_cur = RLIM_INFINITY,
+		.rlim_max = RLIM_INFINITY,
+	};
+
+	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
+}
+
+char *ipv4_str(struct in_addr *addr)
+{
+	char temp[INET_ADDRSTRLEN];
+
+	memset(temp, 0, INET_ADDRSTRLEN);
+	inet_ntop(AF_INET, addr, temp, INET_ADDRSTRLEN);
+
+	return (char *) strdup(temp);
+}
+
+char *ipv6_str(struct in6_addr *addr)
+{
+	char temp[INET6_ADDRSTRLEN];
+
+	memset(temp, 0, INET6_ADDRSTRLEN);
+	inet_ntop(AF_INET6, addr, temp, INET6_ADDRSTRLEN);
+
+	return (char *) strdup(temp);
+}
+
+static int output(struct data_t *e)
+{
+	struct in_addr src, dst;
+	u16 sport = htons(e->sport);
+	u16 dport = htons(e->dport);
+	char *src_str = NULL, *dst_str = NULL;
+
+	src.s_addr = e->saddr;
+	dst.s_addr = e->daddr;
+
+	switch (e->family) {
+		case AF_INET:
+			src_str = ipv4_str(&src);
+			dst_str = ipv4_str(&dst);
+			break;
+		default:
+			return 0;
+	}
+
+	wrapout("%s (pid: %u) (loginuid: %u) | (%u) %s (%u) => %s (%u)",
+			e->comm, e->pid, e->loginuid, (u8) e->proto,
+			src_str, sport, dst_str, dport);
+
+	if (strstr(dst_str, "127.0.0.1")) {
+		if (dport == 12345) {
+			found = 1; // found the magic connection
+		}
+	}
+
+	free(src_str);
+	free(dst_str);
+
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !bpfverbose)
+		return 0;
+
+	return vfprintf(stderr, format, args);
+}
+
+int usage(int argc, char **argv)
+{
+	fprintf(stdout,
+		"\n"
+		"Syntax: %s [options]\n"
+		"\n"
+		"\t[options]:\n"
+		"\n"
+		"\t-v: bpf verbose mode\n"
+		"\n",
+		argv[0]);
+
+	exit(0);
+}
+
+void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct data_t *e = data;
+
+	output(e);
+
+	return;
+}
+
+void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+void trap(int what)
+{
+	exiting = 1;
+}
+
+int main(int argc, char **argv)
+{
+	int opt, err = 0, pid_max;
+	struct main_bpf *main;
+	struct perf_buffer_opts pb_opts;
+	struct perf_buffer *pb = NULL;
+
+	while ((opt = getopt(argc, argv, "hvd")) != -1) {
+		switch(opt) {
+			case 'v':
+				bpfverbose = 1;
+				break;
+			case 'h':
+			default:
+				usage(argc, argv);
+		}
+	}
+
+	signal(SIGINT, trap);
+	signal(SIGTERM, trap);
+
+	fprintf(stdout, "Listening for tcp_connect(), <Ctrl-C> or or SIG_TERM to end it.\n");
+
+	libbpf_set_print(libbpf_print_fn);
+
+	if ((err = bump_memlock_rlimit()))
+		exiterr("failed to increase rlimit: %d", err);
+
+	if ((pid_max = get_pid_max()) < 0)
+		exiterr("failed to get pid_max");
+
+	// create BPF module using BPF object file
+	if (!(main = main_bpf__open()))
+		exiterr("failed to open BPF object");
+
+	// load BPF object from BPF module
+	if ((err = main_bpf__load(main)))
+		exiterr("failed to load BPF object: %d\n", err);
+
+	// attach to BPF program to kprobe
+	if ((err = main_bpf__attach(main)))
+		exiterr("failed to attach\n");
+
+	pb_opts.sample_cb = handle_event;
+	pb_opts.lost_cb = handle_lost_events;
+
+	// start perf event polling (call handle_event & handle_lost_events on fd activity)
+	pb = perf_buffer__new(bpf_map__fd(main->maps.events), 16 /* BUFFER PAGES */, &pb_opts);
+
+	err = libbpf_get_error(pb);
+	if (err) {
+		pb = NULL;
+		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	while (1) {
+		if ((err = perf_buffer__poll(pb, 100)) < 0) {
+			err = 1; // real error
+			goto cleanup;
+		}
+
+		if (exiting) {
+			err = 1; // not supposed to exit until magic connection
+			goto cleanup;
+		}
+
+		if (found) {
+			err = 0; // test succeeded
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	perf_buffer__free(pb);
+	main_bpf__destroy(main);
+	exit(err);
+}

--- a/selftest/tcpconnect/main.go
+++ b/selftest/tcpconnect/main.go
@@ -1,0 +1,201 @@
+package main
+
+/*
+#include <arpa/inet.h>
+#include <netinet/in.h>
+*/
+
+import "C"
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	bpf "github.com/aquasecurity/libbpfgo"
+	"net"
+	"os"
+	"time"
+)
+
+func okexit() {
+	fmt.Fprintf(os.Stdout, "success\n")
+	os.Exit(0)
+}
+
+func errexit(why error) {
+	fmt.Fprintf(os.Stdout, "error: %s\n", why)
+	os.Exit(1)
+}
+
+func errtimeout() {
+	fmt.Fprintf(os.Stdout, "timeout\n")
+	os.Exit(3)
+}
+
+// I have not packed the data struct shared among bpf and userland
+// discover holes and paddings with: pahole -C struct_name ./binary
+type data struct {
+	Comm      [16]byte // 00 - 16 : command (task_comm_len)
+	Pid       uint32   // 16 - 20 : process id
+	Uid       uint32   // 20 - 24 : user id
+	Gid       uint32   // 24 - 28 : group id
+	LoginUid  uint32   // 28 - 32 : real user (login/terminal)
+	Family    uint8    // 32 - 33 : network family
+	Proto     uint8    // 33 - 34 : protocol (sock.h: u8 older, u16 newer)
+	SPort     uint16   // 34 - 36 : source port
+	DPort     uint16   // 36 - 38 : dest port
+	_         [2]byte  // 38 - 40 : -- (hole for cache align)
+	SAddr     uint32   // 40 - 44 : source address
+	SAddr6    [16]byte // 44 - 60 : source address (IPv6)
+	DAddr     uint32   // 60 - 64 : dest address
+	DAddr6    [16]byte // 64 - 80 : dest address (IPv6)
+	TheSource uint8    // 80 - 81 : am I originating the packet ?
+	_         [3]byte  // 81 - 84 : -- (padding, total = 84 bytes)
+}
+
+type gdata struct {
+	Comm     string
+	Pid      uint
+	Uid      uint
+	Gid      uint
+	LoginUid uint
+	Family   uint
+	Proto    uint
+	SPort    uint
+	DPort    uint
+	SAddr    string
+	DAddr    string
+}
+
+func main() {
+
+	var err error
+
+	var bpfModule *bpf.Module
+	var bpfMapEvents *bpf.BPFMap
+	var bpfProgTcpConnect *bpf.BPFProg
+	var perfBuffer *bpf.PerfBuffer
+
+	var eventsChannel chan []byte
+	var lostChannel chan uint64
+
+	// create BPF module using BPF object file
+	bpfModule, err = bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		errexit(err)
+	}
+	defer bpfModule.Close()
+
+	// BPF map "events": resize it before object is loaded
+	bpfMapEvents, err = bpfModule.GetMap("events")
+	err = bpfMapEvents.Resize(8192)
+	if err != nil {
+		errexit(err)
+	}
+
+	// load BPF object from BPF module
+	if err = bpfModule.BPFLoadObject(); err != nil {
+		errexit(err)
+	}
+
+	// get BPF program from BPF object
+	bpfProgTcpConnect, err = bpfModule.GetProgram("tcp_connect")
+	if err != nil {
+		errexit(err)
+	}
+
+	// attach to BPF program to kprobe
+	_, err = bpfProgTcpConnect.AttachKprobe("tcp_connect")
+	if err != nil {
+		errexit(err)
+	}
+
+	// channel for events (and lost events)
+	eventsChannel = make(chan []byte)
+	lostChannel = make(chan uint64)
+
+	perfBuffer, err = bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)
+	if err != nil {
+		errexit(err)
+	}
+
+	// start perf event polling (will receive events through eventChannel)
+	perfBuffer.Start()
+
+	fmt.Println("Listening for tcp_connect(), <Ctrl-C> or or SIG_TERM to end it.")
+
+	timeout := make(chan bool)
+	allgood := make(chan bool)
+
+	go func() {
+		time.Sleep(60 * time.Second) // this timeout is bigger than Makefile one
+		timeout <- true
+	}()
+
+	go func() {
+		// receive events until channel is closed
+		for dataRaw := range eventsChannel {
+
+			var dt data
+			var dataBuffer *bytes.Buffer
+
+			dataBuffer = bytes.NewBuffer(dataRaw)
+
+			err = binary.Read(dataBuffer, binary.LittleEndian, &dt)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+
+			var bsport = make([]byte, 2)
+			var bdport = make([]byte, 2)
+			binary.BigEndian.PutUint16(bsport, dt.SPort)
+			binary.BigEndian.PutUint16(bdport, dt.DPort)
+
+			godata := gdata{
+				Comm:     string(bytes.TrimRight(dt.Comm[:], "\x00")),
+				Pid:      uint(dt.Pid),
+				Uid:      uint(dt.Uid),
+				Gid:      uint(dt.Gid),
+				LoginUid: uint(dt.LoginUid),
+				Family:   uint(dt.Family),
+				Proto:    uint(dt.Proto),
+				SPort:    uint(binary.LittleEndian.Uint16(bsport)),
+				DPort:    uint(binary.LittleEndian.Uint16(bdport)),
+			}
+
+			// TCPv4 only example
+
+			if godata.Family == 2 {
+
+				var LeSAddr = make([]byte, 4)
+				var LeDAddr = make([]byte, 4)
+
+				binary.LittleEndian.PutUint32(LeSAddr, dt.SAddr)
+				binary.LittleEndian.PutUint32(LeDAddr, dt.DAddr)
+				godata.SAddr = net.IP.String(LeSAddr)
+				godata.DAddr = net.IP.String(LeDAddr)
+
+				fmt.Fprintf(os.Stdout, "%s (pid: %d) (loginuid: %d) | (proto: %d) %s (%d) => %s (%d)\n",
+					godata.Comm, godata.Pid,
+					godata.LoginUid, godata.Proto,
+					godata.SAddr, godata.SPort,
+					godata.DAddr, godata.DPort)
+
+				if godata.DAddr == "127.0.0.1" {
+					if godata.DPort == 12345 {
+						// magic connection makes test succeed
+						allgood <- true
+					}
+				}
+			}
+		}
+	}()
+
+	select {
+	case <- allgood:
+		okexit()
+	case <- timeout:
+		errtimeout()
+	}
+}

--- a/selftest/tcpconnect/run.sh
+++ b/selftest/tcpconnect/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SETTINGS
+
+TEST=$(dirname $0)/$1	# execute
+
+SERVER=$(dirname $0)/tcpserver
+CLIENT=$(dirname $0)/tcpclient
+
+# COMMON
+
+COMMON="$(dirname $0)/../common/common.sh"
+[[ -f $COMMON ]] && { . $COMMON; } || { error "no common"; exit 1; }
+
+# MAIN
+
+kern_version gt 5.2
+check_build
+check_ppid
+execbg 20 $SERVER
+execbg 20 $CLIENT
+execfg 10 $TEST
+test_finish
+
+waitbg
+
+exit 0

--- a/selftest/tcpconnect/tcpclient
+++ b/selftest/tcpconnect/tcpclient
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sleep 5
+exec 3<>/dev/tcp/127.0.0.1/12345
+echo "connected" >&3

--- a/selftest/tcpconnect/tcpserver
+++ b/selftest/tcpconnect/tcpserver
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+nc -l -p 12345 > /dev/null


### PR DESCRIPTION
$ make -C selftest/tcpconnect
$ make -C selftest/tcpconnect run

will build:

- tcpconnect-static
- tcpconnect-dynamic
- tcpconnect-go-static
- tcpconnect-go-dynamic

as an example on how to use libbpfgo (or libbpf) to probe kernel
function "tcp_connection" and get data from it. It will also use
this example as a selftest for a simple TCP connect().