### PR TITLE
Fix init_perf_buf error handling

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -70,7 +70,7 @@ struct perf_buffer * init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx) {
     pb_opts.lost_cb = perfLostCallback;
     pb_opts.ctx = (void*)ctx;
     pb = perf_buffer__new(map_fd, page_cnt, &pb_opts);
-    if (pb < 0) {
+    if (libbpf_get_error(pb)) {
         fprintf(stderr, "Failed to initialize perf buffer!\n");
         return NULL;
     }


### PR DESCRIPTION
While investigating [different capabilities](https://github.com/aquasecurity/tracee/issues/747) to avoid `sudo`,  I get

```
./tracee-ebpf 
libbpf: failed to mmap perf buffer on cpu #7: Operation not permitted
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3f pc=0x713b73]

runtime stack:
runtime.throw(0x7e9fe6, 0x2a)
	/usr/local/go/src/runtime/panic.go:1117 +0x72
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:718 +0x2e5
...
```

The PR fixes error handling to properly stop the service instead of starting it without the perf buffers.

```
./tracee-ebpf 
libbpf: failed to mmap perf buffer on cpu #7: Operation not permitted
Failed to initialize perf buffer!
2021/08/05 14:27:37 error creating Tracee: error initializing file_writes perf map: failed to initialize perf buffer
```