### PR TITLE
libbpfgo: run lint tool and fix issues

### DIFF
--- a/helpers/argumentParsers.go
+++ b/helpers/argumentParsers.go
@@ -95,6 +95,7 @@ func ParseMemProt(prot uint32) string {
 			f = append(f, "PROT_EXEC")
 		}
 	}
+
 	return strings.Join(f, "|")
 }
 
@@ -104,7 +105,7 @@ func ParseMemProt(prot uint32) string {
 func ParseOpenFlags(flags uint32) string {
 	var f []string
 
-	//access mode
+	// access mode
 	switch {
 	case flags&01 == 01:
 		f = append(f, "O_WRONLY")
@@ -184,6 +185,7 @@ func ParseAccessMode(mode uint32) string {
 			f = append(f, "X_OK")
 		}
 	}
+
 	return strings.Join(f, "|")
 }
 
@@ -200,6 +202,7 @@ func ParseExecFlags(flags uint32) string {
 	if len(f) == 0 {
 		f = append(f, "0")
 	}
+
 	return strings.Join(f, "|")
 }
 
@@ -282,6 +285,7 @@ func ParseCloneFlags(flags uint64) string {
 	if len(f) == 0 {
 		f = append(f, "0")
 	}
+
 	return strings.Join(f, "|")
 }
 
@@ -297,7 +301,9 @@ func ParseSocketType(st uint32) string {
 		6:  "SOCK_DCCP",
 		10: "SOCK_PACKET",
 	}
+
 	var f []string
+
 	if stName, ok := socketTypes[st&0xf]; ok {
 		f = append(f, stName)
 	} else {
@@ -309,6 +315,7 @@ func ParseSocketType(st uint32) string {
 	if st&002000000 == 002000000 {
 		f = append(f, "SOCK_CLOEXEC")
 	}
+
 	return strings.Join(f, "|")
 }
 
@@ -362,12 +369,15 @@ func ParseSocketDomain(sd uint32) string {
 		43: "AF_SMC",
 		44: "AF_XDP",
 	}
+
 	var res string
+
 	if sdName, ok := socketDomains[sd]; ok {
 		res = sdName
 	} else {
 		res = strconv.Itoa(int(sd))
 	}
+
 	return res
 }
 
@@ -375,19 +385,23 @@ func ParseSocketDomain(sd uint32) string {
 func ParseUint32IP(in uint32) string {
 	ip := make(net.IP, net.IPv4len)
 	binary.BigEndian.PutUint32(ip, in)
+
 	return ip.String()
 }
 
-// Parse16BytesSliceIP parses the IP address encoded as 16 bytes long PrintBytesSliceIP
-// It would be more correct to accept a [16]byte instead of variable lenth slice, but that would case unnecessary memory copying and type conversions
+// Parse16BytesSliceIP parses the IP address encoded as 16 bytes long
+// PrintBytesSliceIP. It would be more correct to accept a [16]byte instead of
+// variable lenth slice, but that would case unnecessary memory copying and
+// type conversions.
 func Parse16BytesSliceIP(in []byte) string {
 	ip := net.IP(in)
+
 	return ip.String()
 }
 
-// ParseCapability parses the `capability` bitmask argument of the `cap_capable` function
-// include/uapi/linux/capability.h
-func ParseCapability(cap int32) string {
+// ParseCapability parses the `capability` bitmask argument of the
+// `cap_capable` function include/uapi/linux/capability.h
+func ParseCapability(c int32) string {
 	var capabilities = map[int32]string{
 		0:  "CAP_CHOWN",
 		1:  "CAP_DAC_OVERRIDE",
@@ -428,12 +442,15 @@ func ParseCapability(cap int32) string {
 		36: "CAP_BLOCK_SUSPEND",
 		37: "CAP_AUDIT_READ",
 	}
+
 	var res string
-	if capName, ok := capabilities[cap]; ok {
+
+	if capName, ok := capabilities[c]; ok {
 		res = capName
 	} else {
-		res = strconv.Itoa(int(cap))
+		res = strconv.Itoa(int(c))
 	}
+
 	return res
 }
 
@@ -501,6 +518,7 @@ func ParsePrctlOption(op int32) string {
 	} else {
 		res = strconv.Itoa(int(op))
 	}
+
 	return res
 }
 
@@ -549,6 +567,7 @@ func ParsePtraceRequest(req int64) string {
 	} else {
 		res = strconv.Itoa(int(req))
 	}
+
 	return res
 }
 
@@ -599,5 +618,6 @@ func ParseBPFCmd(cmd int32) string {
 	} else {
 		res = strconv.Itoa(int(cmd))
 	}
+
 	return res
 }

--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -9,15 +9,14 @@ import (
 // SymbolToOffset attempts to resolve a 'symbol' name in the binary found at
 // 'path' to an offset. The offset can be used for attaching a u(ret)probe
 func SymbolToOffset(path, symbol string) (uint32, error) {
-
 	f, err := elf.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %v", err)
+		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %w", err)
 	}
 
 	syms, err := f.Symbols()
 	if err != nil {
-		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %v", err)
+		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %w", err)
 	}
 
 	sectionsToSearchForSymbol := []*elf.Section{}
@@ -29,14 +28,14 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 	}
 
 	var executableSection *elf.Section
-	for i := range syms {
-		if syms[i].Name == symbol {
 
+	for j := range syms {
+		if syms[j].Name == symbol {
 			// Find what section the symbol is in by checking the executable section's
 			// addr space.
 			for m := range sectionsToSearchForSymbol {
-				if syms[i].Value > sectionsToSearchForSymbol[m].Addr &&
-					syms[i].Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
+				if syms[j].Value > sectionsToSearchForSymbol[m].Addr &&
+					syms[j].Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
 					executableSection = sectionsToSearchForSymbol[m]
 				}
 			}
@@ -45,8 +44,9 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 				return 0, errors.New("could not find symbol in executable sections of binary")
 			}
 
-			return uint32(syms[i].Value - executableSection.Addr + executableSection.Offset), nil
+			return uint32(syms[j].Value - executableSection.Addr + executableSection.Offset), nil
 		}
 	}
+
 	return 0, fmt.Errorf("symbol not found")
 }

--- a/helpers/kernel_features_test.go
+++ b/helpers/kernel_features_test.go
@@ -15,7 +15,7 @@ func TestGetProcGZConfigByPath(t *testing.T) {
 		expectedError  error
 	}{
 		{
-			name:           "non-existant",
+			name:           "non-existent",
 			goldenFilePath: "foobarblahblahblah",
 			expectedMap:    KernelConfig{},
 			expectedError:  errors.New("could not open foobarblahblahblah: open foobarblahblahblah: no such file or directory"),
@@ -42,7 +42,6 @@ func TestGetProcGZConfigByPath(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-
 			var kconfig KernelConfig = make(map[uint32]string)
 			err := kconfig.getProcGZConfigByPath(tt.goldenFilePath)
 			assert.Equal(t, tt.expectedError, err)

--- a/helpers/rwArray.go
+++ b/helpers/rwArray.go
@@ -39,6 +39,7 @@ func (a *RWArray) Put(v interface{}) int {
 		if !a.slots[i].used {
 			a.slots[i].value = v
 			a.slots[i].used = true
+
 			return i
 		}
 	}

--- a/helpers/tracelisten.go
+++ b/helpers/tracelisten.go
@@ -15,19 +15,20 @@ import (
 func TracePipeListen() error {
 	f, err := os.Open("/sys/kernel/debug/tracing/trace_pipe")
 	if err != nil {
-		return fmt.Errorf("failed to open trace pipe: %v", err)
+		return fmt.Errorf("failed to open trace pipe: %w", err)
 	}
 	defer f.Close()
 
 	r := bufio.NewReader(f)
 	b := make([]byte, 1024)
+
 	for {
-		len, err := r.Read(b)
+		l, err := r.Read(b)
 		if err != nil {
-			return fmt.Errorf("failed to read from trace pipe: %v", err)
+			return fmt.Errorf("failed to read from trace pipe: %w", err)
 		}
 
-		s := string(b[:len])
+		s := string(b[:l])
 		fmt.Println(s)
 	}
 }

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -297,10 +297,10 @@ func errptrError(ptr unsafe.Pointer, format string, args ...interface{}) error {
 }
 
 func NewModuleFromFile(bpfObjPath string) (*Module, error) {
-	return NewModuleFromFileBtf("", bpfObjPath)
+	return NewModuleFromFileBTF("", bpfObjPath)
 }
 
-func NewModuleFromFileBtf(btfObjPath string, bpfObjPath string) (*Module, error) {
+func NewModuleFromFileBTF(btfObjPath string, bpfObjPath string) (*Module, error) {
 	C.set_print_fn()
 	if err := bumpMemlockRlimit(); err != nil {
 		return nil, err

--- a/selftest/tcpconnect/main.go
+++ b/selftest/tcpconnect/main.go
@@ -193,9 +193,9 @@ func main() {
 	}()
 
 	select {
-	case <- allgood:
+	case <-allgood:
 		okexit()
-	case <- timeout:
+	case <-timeout:
 		errtimeout()
 	}
 }

--- a/selftest/uprobe/test.go
+++ b/selftest/uprobe/test.go
@@ -15,7 +15,7 @@ func testFunction() int {
 
 func main() {
 	for {
-		time.Sleep(100 * time.Millisecond);
+		time.Sleep(100 * time.Millisecond)
 		testFunction()
 	}
 }


### PR DESCRIPTION
$ golangci-lint run -E asciicheck -E bodyclose \
    -E depguard -E dogsled -E dupl -E durationcheck -E errorlint \
    -E exhaustive -E exportloopref \
    -E forcetypeassert -E gci \
    -E gochecknoinits -E gocognit -E goconst -E gocritic \
    -E godox -E gofmt -E gofumpt -E goheader \
    -E goimports -E gomoddirectives -E gomodguard \
    -E goprintffuncname -E gosec -E importas \
    -E lll -E makezero -E misspell \
    -E nakedret -E nestif -E nilerr -E nlreturn -E noctx -E nolintlint \
    -E paralleltest -E prealloc -E predeclared -E promlinter -E revive \
    -E rowserrcheck -E stylecheck \
    -E tagliatelle -E testpackage -E thelper -E tparallel -E unconvert \
    -E unparam -E wastedassign -E whitespace -E wsl