### PR TITLE
checking if new operation in newbtfino succeeded

### DIFF
--- a/helpers/btfinfo.go
+++ b/helpers/btfinfo.go
@@ -45,6 +45,9 @@ func BTFEnabled() bool {
 // by itself.
 func NewBTFInfo() *BTFInfo {
 	btfi := new(BTFInfo)
+	if btfi == nil {
+		return nil
+	}
 
 	if err := btfi.DiscoverDistro(); err != nil {
 		return nil


### PR DESCRIPTION
We now check if new operation succeeded. so that in case it didn't we don't panic by calling DiscoverDistro().

The user of the NewBTFInfo function is responsible to check if the returned error is not nil.