### PR TITLE
add parser for kernel_read_file_id enum

### DIFF
--- a/helpers/argumentParsers.go
+++ b/helpers/argumentParsers.go
@@ -635,9 +635,7 @@ func UnameRelease() string {
 		buf[i] = byte(b)
 	}
 	ver := string(buf[:])
-	if i := strings.Index(ver, "\x00"); i != -1 {
-		ver = ver[:i]
-	}
+	ver = strings.Trim(ver, "\x00")
 	return ver
 }
 

--- a/helpers/argumentParsers.go
+++ b/helpers/argumentParsers.go
@@ -696,8 +696,8 @@ func ParseKernelReadFileId(id int32) (string, error) {
 			7: "security-policy",
 			8: "x509-certificate",
 		}
-	} else if (major == 5 && minor == 8 && subMinor == 18) || (major == 5 && minor < 7) || major < 5 {
-		// kernel version: <5.7 || ==5.8.18
+	} else if ((major == 5 && minor == 8 && subMinor == 18) || (major == 5 && minor < 7) || major < 5) && ((major == 4 && minor >= 18) || major == 5) {
+		// kernel version: ==5.8.18 || (<5.7 && >=4.18)
 		kernelReadFileIdStrs = map[int32]string{
 			0: "unknown",
 			1: "firmware",

--- a/helpers/argumentParsers.go
+++ b/helpers/argumentParsers.go
@@ -639,6 +639,8 @@ func UnameRelease() string {
 	return ver
 }
 
+// ParseKernelReadFileId get an id of type enum kernel_read_file_id. this enum specifies what type of file is being
+// loaded into the kernel. see: https://elixir.bootlin.com/linux/v5.14/source/include/linux/kernel_read_file.h#L22
 func ParseKernelReadFileId(id int32) (string, error) {
 
 	kernelVersion := UnameRelease()


### PR DESCRIPTION
kernel_read_file_id in an enum that tells what is being read into the kernel. if merged - it'll be used by security_kernel_read_file event in tracee-ebpf.
this enum was changed between kernel versions.