### PR TITLE
libbpfgo: make AttachTracepoint() signature 1:1 with libbpf

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -752,25 +752,21 @@ func (p *BPFProg) SetTracepoint() error {
 	return nil
 }
 
-func (p *BPFProg) AttachTracepoint(tp string) (*BPFLink, error) {
-	tpEvent := strings.Split(tp, ":")
-	if len(tpEvent) != 2 {
-		return nil, fmt.Errorf("tracepoint must be in 'category:name' format")
-	}
-	tpCategory := C.CString(tpEvent[0])
-	tpName := C.CString(tpEvent[1])
+func (p *BPFProg) AttachTracepoint(category, name string) (*BPFLink, error) {
+	tpCategory := C.CString(category)
+	tpName := C.CString(name)
 	link := C.bpf_program__attach_tracepoint(p.prog, tpCategory, tpName)
 	C.free(unsafe.Pointer(tpCategory))
 	C.free(unsafe.Pointer(tpName))
 	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
-		return nil, errptrError(unsafe.Pointer(link), "failed to attach tracepoint %s to program %s", tp, p.name)
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach tracepoint %s to program %s", name, p.name)
 	}
 
 	bpfLink := &BPFLink{
 		link:      link,
 		prog:      p,
 		linkType:  Tracepoint,
-		eventName: tp,
+		eventName: name,
 	}
 	p.module.links = append(p.module.links, bpfLink)
 	return bpfLink, nil

--- a/libbpfgo_test.go
+++ b/libbpfgo_test.go
@@ -2,6 +2,7 @@ package libbpfgo
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -38,7 +39,11 @@ func Test_LoadAndAttach(t *testing.T) {
 			prog:      "tracepoint__sys_enter_dup",
 			attachArg: "syscalls:sys_enter_dup",
 			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
-				return prog.AttachTracepoint(name)
+				tpEvent := strings.Split(name, ":")
+				if len(tpEvent) != 2 {
+					return nil, fmt.Errorf("tracepoint must be in 'category:name' format")
+				}
+				return prog.AttachTracepoint(tpEvent[0], tpEvent[1])
 			},
 		},
 		{


### PR DESCRIPTION
These changes, along with some refactoring, also update the `libbpfgo_test.go`.

Fixes:  #75