### PR TITLE
Fix NewModuleFromBuffer

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -197,7 +197,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -356,7 +355,7 @@ func NewModuleFromFileArgs(args NewModuleArgs) (*Module, error) {
 
 func NewModuleFromBuffer(bpfObjBuff []byte, bpfObjName string) (*Module, error) {
 
-	return NewModuleFromFileArgs(NewModuleArgs{
+	return NewModuleFromBufferArgs(NewModuleArgs{
 		BPFObjBuff: bpfObjBuff,
 		BPFObjName: bpfObjName,
 	})


### PR DESCRIPTION
NewModuleFromBuffer was calling NewModuleFromFileArgs instead of
NewModuleFromBufferArgs which ended up causing the following error to
start coming through:

libbpf: elf: failed to open : No such file or directory

This patch fixes it by calling the correct function.