### PR TITLE
selftests: ringbuffers: give time to ringbuffer consumer

### DIFF
--- a/selftest/ringbuffers/main.go
+++ b/selftest/ringbuffers/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"os"
 	"syscall"
+	"time"
 
 	"encoding/binary"
 	"fmt"
@@ -69,6 +70,7 @@ func main() {
 	go func() {
 		for {
 			syscall.Mmap(999, 999, 999, 1, 1)
+			time.Sleep(time.Second / 2)
 		}
 	}()
 recvLoop:


### PR DESCRIPTION
Depending on the hardware used in this test, the result was either error or success.

I put some prints and found that in the test with faster hardware, the loader, when trying to consume the rinbuffer, was already in an overflowed state.


Debugging with the infamous print:

```c
char LICENSE[] SEC("license") = "Dual BSD/GPL";

long ringbuffer_flags = 0;

SEC("kprobe/sys_mmap")
int kprobe__sys_mmap(struct pt_regs *ctx)
{
    int *process;

    bpf_printk("before");

    // Reserve space on the ringbuffer for the sample
    process = bpf_ringbuf_reserve(&events, sizeof(int), 0);
    if (!process) {
        return 0;
    }

    bpf_printk("between");

    *process = 2021;

    bpf_ringbuf_submit(process, 0);

    bpf_printk("after");

    return 0;
}

```


The output of trace_pipe:

```shell
...
     main-static-11511   [007] d..3  2237.755619: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.755619: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.755620: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.755620: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.755620: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.755621: bpf_trace_printk: before
CPU:7 [LOST 1020 EVENTS]
     main-static-11511   [007] d..3  2237.756004: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.756005: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.756005: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.756005: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.756006: bpf_trace_printk: before
     main-static-11511   [007] d..3  2237.756006: bpf_trace_printk: before
...

```
This way, I added a sleep between the syscall mmap calls, allowing the loader to breathe and be able to consume the ringbuffer before it fills up.

Fixes #85