### PR TITLE
helpers/osinfo: host architecture detection

### DIFF
--- a/helpers/btfhub.go
+++ b/helpers/btfhub.go
@@ -1,0 +1,2 @@
+package helpers
+

--- a/helpers/common.go
+++ b/helpers/common.go
@@ -38,6 +38,28 @@ func UnameRelease() (string, error) {
 	return ver, nil
 }
 
+// UnameMachine gets the version string of host's architecture
+func UnameMachine() (string, error) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return "", fmt.Errorf("could not get utsname")
+	}
+
+	var buf [65]byte
+	for i, b := range uname.Machine {
+		buf[i] = byte(b)
+	}
+
+	arch := string(buf[:])
+	arch = strings.Trim(arch, "\x00")
+
+	if strings.Contains(arch, "aarch64") {
+		arch = "arm64"
+	}
+
+	return arch, nil
+}
+
 // CompareKernelRelease will compare two given kernel version/release
 // strings and return -1, 0 or 1 if given version is less, equal or bigger,
 // respectively, than the given one

--- a/helpers/osinfo.go
+++ b/helpers/osinfo.go
@@ -58,7 +58,9 @@ const (
 	OS_BUILD_ID
 	OS_IMAGE_ID
 	OS_IMAGE_VERSION
-	OS_KERNEL_RELEASE // not part of default os-release, but we can use it here to facilitate things
+	// not part of default os-release:
+	OS_KERNEL_RELEASE
+	OS_ARCH
 )
 
 type OSReleaseField uint32
@@ -82,6 +84,7 @@ var stringToOSReleaseField = map[string]OSReleaseField{
 	"IMAGE_ID":         OS_IMAGE_ID,
 	"IMAGE_VERSION":    OS_IMAGE_VERSION,
 	"KERNEL_RELEASE":   OS_KERNEL_RELEASE,
+	"ARCH":             OS_ARCH,
 }
 
 // osReleaseFieldToString is a map of os-release file fields
@@ -99,6 +102,7 @@ var osReleaseFieldToString = map[OSReleaseField]string{
 	OS_IMAGE_ID:         "IMAGE_ID",
 	OS_IMAGE_VERSION:    "IMAGE_VERSION",
 	OS_KERNEL_RELEASE:   "KERNEL_RELEASE",
+	OS_ARCH:             "ARCH",
 }
 
 // OSBTFEnabled checks if kernel has embedded BTF vmlinux file
@@ -120,6 +124,11 @@ func GetOSInfo() (*OSInfo, error) {
 	info.osReleaseFieldValues[OS_KERNEL_RELEASE], err = UnameRelease()
 	if err != nil {
 		return &info, fmt.Errorf("could not determine uname release: %w", err)
+	}
+
+	info.osReleaseFieldValues[OS_ARCH], err = UnameMachine()
+	if err != nil {
+		return &info, fmt.Errorf("could not determine uname machine: %w", err)
 	}
 
 	info.osReleaseFilePath, err = checkEnvPath("LIBBPFGO_OSRELEASE_FILE") // useful if users wants to mount host os-release in a container

--- a/helpers/osinfo.go
+++ b/helpers/osinfo.go
@@ -139,8 +139,8 @@ func GetOSInfo() (*OSInfo, error) {
 // OSInfo object contains all OS relevant information
 //
 // OSRelease is relevant to examples such as:
-// 1) OSInfo.OSReleaseInfo[helpers.OS_KERNEL_RELEASE]) => will provide $(uname -r) string
-// 2) if OSInfo.GetReleaseID() == helpers.UBUNTU => {} will allow to run code in specific distribution
+// 1) OSInfo.OSReleaseInfo[helpers.OS_KERNEL_RELEASE] => will provide $(uname -r) string
+// 2) if OSInfo.GetReleaseID() == helpers.UBUNTU => {} will allow running code in specific distribution
 //
 type OSInfo struct {
 	osReleaseFieldValues map[OSReleaseField]string
@@ -159,7 +159,7 @@ func (btfi *OSInfo) GetOSReleaseFilePath() string {
 	return btfi.osReleaseFilePath
 }
 
-// GetOSReleaseFilePath provides the ID of current Linux distribution
+// GetOSReleaseID provides the ID of current Linux distribution
 func (btfi *OSInfo) GetOSReleaseID() OSReleaseID {
 	return btfi.osReleaseID
 }


### PR DESCRIPTION
osinfo needs to detect the host architecture in order to support the embedded BTF files feature being added to tracee.