### PR TITLE
libbpfgo: Add map batch operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,13 @@ libbpfgo-static: $(VMLINUXH) | $(LIBBPF_OBJ)
 
 libbpfgo-static-test: libbpfgo-test-bpf-static
 	sudo env PATH=$(PATH) \
-	CC=$(CLANG) \
-	CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
-	CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
-	GOOS=linux GOARCH=$(ARCH) \
-	go test \
-	-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
-	.
+		CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
+		GOOS=linux GOARCH=$(ARCH) \
+		go test \
+		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
+		.
 
 # vmlinux header file
 

--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,14 @@ libbpfgo-static: $(VMLINUXH) | $(LIBBPF_OBJ)
 		.
 
 libbpfgo-static-test: libbpfgo-test-bpf-static
+	sudo env PATH=$(PATH) \
 	CC=$(CLANG) \
-		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
-		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
-		GOOS=linux GOARCH=$(ARCH) \
-		sudo -E -- go test \
-		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
-		.
+	CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
+	CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
+	GOOS=linux GOARCH=$(ARCH) \
+	go test \
+	-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
+	.
 
 # vmlinux header file
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ libbpfgo-static-test: libbpfgo-test-bpf-static
 		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
 		GOOS=linux GOARCH=$(ARCH) \
 		go test \
-		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
+		-v -tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
 		.
 
 # vmlinux header file

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -600,6 +600,10 @@ func bpfMapBatchOptsToC(batchOpts *BPFMapBatchOpts) *C.struct_bpf_map_batch_opts
 // GetValueBatch allows for batch lookups of multiple keys.
 // The first argument is a pointer to an array or slice of keys which will be populated with the keys returned from this operation.
 // It returns the associated values as a slice of slices of bytes.
+// This API allows for batch lookups of multiple keys, potentially in steps over multiple iterations. For example,
+// you provide the last key seen (or nil) for the startKey, and the first key to start the next iteration with in nextKey.
+// Once the first iteration is complete you can provide the last key seen in the previous iteration as the startKey for the next iteration
+// and for forth until nextKey is nil.
 func (b *BPFMap) GetValueBatch(keys unsafe.Pointer, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, error) {
 	var (
 		values    = make([]byte, b.ValueSize()*int(count))

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -598,7 +598,7 @@ func bpfMapBatchOptsToC(batchOpts *BPFMapBatchOpts) *C.struct_bpf_map_batch_opts
 }
 
 // GetValueBatch allows for batch lookups of multiple keys.
-// The first argument is a pointer to an array of keys which will be populated with the keys returned from this operation.
+// The first argument is a pointer to an array or slice of keys which will be populated with the keys returned from this operation.
 // It returns the associated values as a slice of slices of bytes.
 func (b *BPFMap) GetValueBatch(keys unsafe.Pointer, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, error) {
 	var (

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -578,6 +578,116 @@ func (b *BPFMap) GetValue(key unsafe.Pointer) ([]byte, error) {
 	return value, nil
 }
 
+// BPFMapBatchOpts mirrors the C structure bpf_map_batch_opts.
+type BPFMapBatchOpts struct {
+	Sz        uint64
+	ElemFlags uint64
+	Flags     uint64
+}
+
+func bpfMapBatchOptsToC(batchOpts *BPFMapBatchOpts) *C.struct_bpf_map_batch_opts {
+	if batchOpts == nil {
+		return nil
+	}
+	opts := C.struct_bpf_map_batch_opts{}
+	opts.sz = C.ulong(batchOpts.Sz)
+	opts.elem_flags = C.ulonglong(batchOpts.ElemFlags)
+	opts.flags = C.ulonglong(batchOpts.Flags)
+
+	return &opts
+}
+
+// GetValueBatch allows for batch lookups of multiple keys.
+// The first argument is a pointer to an array of keys which will be populated with the keys returned from this operation.
+// It returns the associated values as a slice of slices of bytes.
+func (b *BPFMap) GetValueBatch(keys unsafe.Pointer, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, error) {
+	var (
+		values    = make([]byte, b.ValueSize()*int(count))
+		valuesPtr = unsafe.Pointer(&values[0])
+		countC    = C.uint(count)
+	)
+
+	opts := &BPFMapBatchOpts{
+		Sz:        uint64(unsafe.Sizeof(BPFMapBatchOpts{})),
+		ElemFlags: C.BPF_ANY,
+		Flags:     C.BPF_ANY,
+	}
+
+	errC := C.bpf_map_lookup_batch(b.fd, startKey, nextKey, keys, valuesPtr, &countC, bpfMapBatchOptsToC(opts))
+	if errC != 0 {
+		return nil, fmt.Errorf("failed to batch lookup values %v in map %s: %d", keys, b.name, errC)
+	}
+
+	parsedVals := collectBatchValues(values, count, b.ValueSize())
+
+	return parsedVals, nil
+}
+
+// GetValueAndDeleteBatch allows for batch lookups of multiple keys and deletes those keys.
+func (b *BPFMap) GetValueAndDeleteBatch(keys, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, error) {
+	var (
+		values    = make([]byte, b.ValueSize()*int(count))
+		valuesPtr = unsafe.Pointer(&values[0])
+		countC    = C.uint(count)
+	)
+
+	opts := &BPFMapBatchOpts{
+		Sz:        uint64(unsafe.Sizeof(BPFMapBatchOpts{})),
+		ElemFlags: C.BPF_ANY,
+		Flags:     C.BPF_ANY,
+	}
+
+	errC := C.bpf_map_lookup_and_delete_batch(b.fd, startKey, nextKey, keys, valuesPtr, &countC, bpfMapBatchOptsToC(opts))
+	if errC != 0 {
+		return nil, fmt.Errorf("failed to batch lookup and delete values %v in map %s", keys, b.name)
+	}
+
+	parsedVals := collectBatchValues(values, count, b.ValueSize())
+
+	return parsedVals, nil
+}
+
+func collectBatchValues(values []byte, count uint32, valueSize int) [][]byte {
+	var value []byte
+	var collected [][]byte
+	for i := 0; i < int(count*uint32(valueSize)); i += valueSize {
+		value = values[i : i+valueSize]
+		collected = append(collected, value)
+	}
+	return collected
+}
+
+// UpdateBatch takes a pointer to an array of keys and values which are then stored in the map.
+func (b *BPFMap) UpdateBatch(keys, values unsafe.Pointer, count uint32) error {
+	countC := C.uint(count)
+	opts := BPFMapBatchOpts{
+		Sz:        uint64(unsafe.Sizeof(BPFMapBatchOpts{})),
+		ElemFlags: C.BPF_ANY,
+		Flags:     C.BPF_ANY,
+	}
+	errC := C.bpf_map_update_batch(b.fd, keys, values, &countC, bpfMapBatchOptsToC(&opts))
+	if errC != 0 {
+		return fmt.Errorf("failed to update map %s: %v", b.name, errC)
+	}
+	return nil
+}
+
+// DeleteKeyBatch will delete `count` keys from the map, returning the keys deleted in the
+// slice pointed to by `keys`.
+func (b *BPFMap) DeleteKeyBatch(keys unsafe.Pointer, count uint32) error {
+	countC := C.uint(count)
+	opts := &BPFMapBatchOpts{
+		Sz:        uint64(unsafe.Sizeof(BPFMapBatchOpts{})),
+		ElemFlags: C.BPF_ANY,
+		Flags:     C.BPF_ANY,
+	}
+	errC := C.bpf_map_delete_batch(b.fd, keys, &countC, bpfMapBatchOptsToC(opts))
+	if errC != 0 {
+		return fmt.Errorf("failed to get lookup key %d from map %s", keys, b.name)
+	}
+	return nil
+}
+
 // DeleteKey takes a pointer to the key which is stored in the map.
 // It removes the key and associated value from the BPFMap.
 // All basic types, and structs are supported as keys.

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -603,7 +603,7 @@ func bpfMapBatchOptsToC(batchOpts *BPFMapBatchOpts) *C.struct_bpf_map_batch_opts
 // This API allows for batch lookups of multiple keys, potentially in steps over multiple iterations. For example,
 // you provide the last key seen (or nil) for the startKey, and the first key to start the next iteration with in nextKey.
 // Once the first iteration is complete you can provide the last key seen in the previous iteration as the startKey for the next iteration
-// and for forth until nextKey is nil.
+// and repeat until nextKey is nil.
 func (b *BPFMap) GetValueBatch(keys unsafe.Pointer, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, error) {
 	var (
 		values    = make([]byte, b.ValueSize()*int(count))

--- a/libbpfgo_test.go
+++ b/libbpfgo_test.go
@@ -1,9 +1,12 @@
 package libbpfgo
 
 import (
+	"encoding/binary"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
+	"unsafe"
 )
 
 func Test_LoadAndAttach(t *testing.T) {
@@ -108,5 +111,104 @@ func Test_LoadAndAttach(t *testing.T) {
 		if _, err = test.attachFn(prog, test.attachArg); err != nil {
 			t.Errorf("test %v: attach failed: %v", i, err)
 		}
+	}
+}
+
+func Test_MapBatchOperations(t *testing.T) {
+	module, err := NewModuleFromFile("selftest/build/libbpfgo_test.bpf.o")
+	if err != nil {
+		t.Fatalf("NewModuleFromFile failed: %v", err)
+	}
+	defer module.Close()
+	module.BPFLoadObject()
+
+	testerMap, err := module.GetMap("tester")
+	if err != nil {
+		t.Fatalf("module.GetMap failed: %v", err)
+	}
+
+	keys := []uint32{1, 2, 3, 4, 5, 6, 8}
+	values := []uint32{2, 3, 4, 5, 6, 7, 9}
+
+	// Test batch update.
+	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
+		t.Fatalf("testerMap.UpdateBatch failed: %v", err)
+	}
+	val, err := testerMap.GetValue(unsafe.Pointer(&keys[0]))
+	if err != nil {
+		t.Fatalf("testerMap.GetValue failed: %v", err)
+	}
+	if binary.LittleEndian.Uint32(val) != values[0] {
+		t.Fatalf("testerMap.GetValue returned %v, expected %v", val, values[0])
+	}
+
+	// Test batch lookup in steps.
+	batchKeys := make([]uint32, 3)
+	nextKey := uint32(0)
+	prevKey := unsafe.Pointer(nil)
+	step := len(batchKeys)
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			// We're on step 2, so test the batch lookup by specifying the
+			// key to start from.
+			prevKey = unsafe.Pointer(&nextKey)
+			log.Printf("prevKey: %v", prevKey)
+		}
+		vals, err := testerMap.GetValueBatch(unsafe.Pointer(&batchKeys[0]), prevKey, unsafe.Pointer(&nextKey), uint32(step))
+		if err != nil {
+			t.Fatalf("step %d testerMap.LookupBatch failed: %v", i, err)
+		}
+		for i, val := range vals {
+			actual := binary.LittleEndian.Uint32(val)
+			expected := batchKeys[i] + 1
+			if actual != expected {
+				t.Fatalf("testerMap.LookupBatch returned %v, expected %v", actual, expected)
+			}
+		}
+	}
+
+	// Test batch lookup and delete.
+	deleteKeys := make([]uint32, 3)
+	nextKey = uint32(0)
+	vals, err := testerMap.GetValueAndDeleteBatch(unsafe.Pointer(&deleteKeys[0]), nil, unsafe.Pointer(&nextKey), uint32(len(deleteKeys)))
+	if err != nil {
+		t.Fatalf("testerMap.LookupBatch failed: %v", err)
+	}
+	for i, val := range vals {
+		actual := binary.LittleEndian.Uint32(val)
+		expected := deleteKeys[i] + 1
+		if actual != expected {
+			t.Fatalf("testerMap.LookupBatch returned %v, expected %v", actual, expected)
+		}
+	}
+
+}
+func Test_MapBatchDeleteOperations(t *testing.T) {
+	module, err := NewModuleFromFile("selftest/build/libbpfgo_test.bpf.o")
+	if err != nil {
+		t.Fatalf("NewModuleFromFile failed: %v", err)
+	}
+	defer module.Close()
+	module.BPFLoadObject()
+
+	testerMap, err := module.GetMap("tester")
+	if err != nil {
+		t.Fatalf("module.GetMap failed: %v", err)
+	}
+
+	keys := []uint32{1, 2, 3, 4, 5, 6, 8}
+	values := []uint32{2, 3, 4, 5, 6, 7, 9}
+
+	// Test batch update.
+	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
+		t.Fatalf("testerMap.UpdateBatch failed: %v", err)
+	}
+	// Test batch delete.
+	testerMap.DeleteKeyBatch(unsafe.Pointer(&keys[0]), uint32(len(keys)))
+
+	// Ensure value is no longer there.
+	_, err = testerMap.GetValue(unsafe.Pointer(&keys[0]))
+	if err == nil {
+		t.Fatalf("testerMap.GetValue was expected to fail, but succeeded")
 	}
 }

--- a/selftest/build/libbpfgo_test.bpf.c
+++ b/selftest/build/libbpfgo_test.bpf.c
@@ -5,6 +5,13 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1<<24);
+} tester SEC(".maps");
+
 SEC("tp/syscalls/sys_enter_dup")
 int tracepoint__sys_enter_dup(struct trace_event_raw_sys_enter *args) {
 	return 0;

--- a/selftest/map-batch/Makefile
+++ b/selftest/map-batch/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/map-batch/go.mod
+++ b/selftest/map-batch/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/map-update
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/map-batch/go.sum
+++ b/selftest/map-batch/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/map-batch/main.bpf.c
+++ b/selftest/map-batch/main.bpf.c
@@ -1,0 +1,43 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct value {
+    int x;
+    char y;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, struct value);
+    __uint(max_entries, 1<<24);
+} tester SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    u32 firstKey = 1;
+    struct value *v1 = bpf_map_lookup_elem(&tester, &firstKey);
+    if (!v1) {
+        return 1;
+    }
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v1, sizeof(struct value));
+
+    int64_t secondKey = 42069420;
+    struct value *v2 = bpf_map_lookup_elem(&tester, &secondKey);
+    if (!v2) {
+        return 1;
+    }
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v2, sizeof(char)*3);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-batch/main.bpf.c
+++ b/selftest/map-batch/main.bpf.c
@@ -2,42 +2,11 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-struct value {
-    int x;
-    char y;
-};
-
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, u32);
-    __type(value, struct value);
+    __type(value, u32);
     __uint(max_entries, 1<<24);
 } tester SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-    __uint(key_size, sizeof(u32));
-    __uint(value_size, sizeof(u32));
-} events SEC(".maps");
-
-SEC("kprobe/sys_mmap")
-int kprobe__sys_mmap(struct pt_regs *ctx)
-{
-    u32 firstKey = 1;
-    struct value *v1 = bpf_map_lookup_elem(&tester, &firstKey);
-    if (!v1) {
-        return 1;
-    }
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v1, sizeof(struct value));
-
-    int64_t secondKey = 42069420;
-    struct value *v2 = bpf_map_lookup_elem(&tester, &secondKey);
-    if (!v2) {
-        return 1;
-    }
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, v2, sizeof(char)*3);
-
-    return 0;
-}
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-batch/main.go
+++ b/selftest/map-batch/main.go
@@ -12,23 +12,6 @@ import (
 	bpf "github.com/aquasecurity/libbpfgo"
 )
 
-func resizeMap(module *bpf.Module, name string, size uint32) error {
-	m, err := module.GetMap("events")
-	if err != nil {
-		return err
-	}
-
-	if err = m.Resize(size); err != nil {
-		return err
-	}
-
-	if actual := m.GetMaxEntries(); actual != size {
-		return fmt.Errorf("map resize failed, expected %v, actual %v", size, actual)
-	}
-
-	return nil
-}
-
 func main() {
 
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
@@ -37,11 +20,6 @@ func main() {
 		os.Exit(-1)
 	}
 	defer bpfModule.Close()
-
-	if err = resizeMap(bpfModule, "events", 8192); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
-	}
 
 	bpfModule.BPFLoadObject()
 

--- a/selftest/map-batch/main.go
+++ b/selftest/map-batch/main.go
@@ -1,0 +1,128 @@
+package main
+
+import "C"
+
+import (
+	"os"
+	"unsafe"
+
+	"encoding/binary"
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func resizeMap(module *bpf.Module, name string, size uint32) error {
+	m, err := module.GetMap("events")
+	if err != nil {
+		return err
+	}
+
+	if err = m.Resize(size); err != nil {
+		return err
+	}
+
+	if actual := m.GetMaxEntries(); actual != size {
+		return fmt.Errorf("map resize failed, expected %v, actual %v", size, actual)
+	}
+
+	return nil
+}
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	bpfModule.BPFLoadObject()
+
+	testerMap, err := bpfModule.GetMap("tester")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	keys := []uint32{1, 2, 3, 4, 5, 6, 8}
+	values := []uint32{2, 3, 4, 5, 6, 7, 9}
+
+	// Test batch update.
+	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
+		fmt.Fprintf(os.Stderr, "testerMap.UpdateBatch failed: %v", err)
+		os.Exit(-1)
+	}
+	val, err := testerMap.GetValue(unsafe.Pointer(&keys[0]))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testerMap.GetValue failed: %v", err)
+		os.Exit(-1)
+	}
+	if binary.LittleEndian.Uint32(val) != values[0] {
+		fmt.Fprintf(os.Stderr, "testerMap.GetValue returned %v, expected %v", val, values[0])
+		os.Exit(-1)
+	}
+
+	// Test batch lookup in steps.
+	batchKeys := make([]uint32, 3)
+	nextKey := uint32(0)
+	prevKey := unsafe.Pointer(nil)
+	step := len(batchKeys)
+	for i := 0; i < 2; i++ {
+		if i > 0 {
+			// We're on step 2, so test the batch lookup by specifying the
+			// key to start from.
+			prevKey = unsafe.Pointer(&nextKey)
+		}
+		vals, err := testerMap.GetValueBatch(unsafe.Pointer(&batchKeys[0]), prevKey, unsafe.Pointer(&nextKey), uint32(step))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "step %d testerMap.LookupBatch failed: %v", i, err)
+			os.Exit(-1)
+		}
+		for i, val := range vals {
+			actual := binary.LittleEndian.Uint32(val)
+			expected := batchKeys[i] + 1
+			if actual != expected {
+				fmt.Fprintf(os.Stderr, "testerMap.LookupBatch returned %v, expected %v", actual, expected)
+				os.Exit(-1)
+			}
+		}
+	}
+
+	// Test batch lookup and delete.
+	deleteKeys := make([]uint32, 3)
+	nextKey = uint32(0)
+	vals, err := testerMap.GetValueAndDeleteBatch(unsafe.Pointer(&deleteKeys[0]), nil, unsafe.Pointer(&nextKey), uint32(len(deleteKeys)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testerMap.LookupBatch failed: %v", err)
+		os.Exit(-1)
+	}
+	for i, val := range vals {
+		actual := binary.LittleEndian.Uint32(val)
+		expected := deleteKeys[i] + 1
+		if actual != expected {
+			fmt.Fprintf(os.Stderr, "testerMap.LookupBatch returned %v, expected %v", actual, expected)
+			os.Exit(-1)
+		}
+	}
+
+	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
+		fmt.Fprintf(os.Stderr, "testerMap.UpdateBatch failed: %v", err)
+		os.Exit(-1)
+	}
+	// Test batch delete.
+	testerMap.DeleteKeyBatch(unsafe.Pointer(&keys[0]), uint32(len(keys)))
+
+	// Ensure value is no longer there.
+	_, err = testerMap.GetValue(unsafe.Pointer(&keys[0]))
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "testerMap.GetValue was expected to fail, but succeeded")
+		os.Exit(-1)
+	}
+}

--- a/selftest/map-batch/run.sh
+++ b/selftest/map-batch/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh


### PR DESCRIPTION
This patch adds a few batch operations for maps including:

Lookup, LookupAndDelete, Update and Delete.