### PR TITLE
Standardize error checking across libbpfgo

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -255,7 +255,7 @@ type BPFLink struct {
 func (l *BPFLink) Destroy() error {
 	ret := C.bpf_link__destroy(l.link)
 	if ret < 0 {
-		return syscall.Errno(-ret)
+		return syscall.Errno(ret)
 	}
 	return nil
 }
@@ -419,7 +419,7 @@ func (m *Module) Close() {
 func (m *Module) BPFLoadObject() error {
 	cErr := C.bpf_object__load(m.obj)
 	if cErr != 0 {
-		return fmt.Errorf("failed to load BPF object", syscall.Errno(int(-cErr)))
+		return fmt.Errorf("failed to load BPF object: %s", syscall.Errno(int(cErr)))
 	}
 
 	return nil
@@ -803,7 +803,7 @@ func (p *BPFProg) Pin(path string) error {
 	cErr := C.bpf_program__pin(p.prog, cs)
 	C.free(unsafe.Pointer(cs))
 	if cErr != 0 {
-		return fmt.Errorf("failed to pin program %s to %s: %s", p.name, path, syscall.Errno(int(-cErr)))
+		return fmt.Errorf("failed to pin program %s to %s: %s", p.name, path, syscall.Errno(int(cErr)))
 	}
 	p.pinnedPath = absPath
 	return nil
@@ -814,7 +814,7 @@ func (p *BPFProg) Unpin(path string) error {
 	cErr := C.bpf_program__unpin(p.prog, cs)
 	C.free(unsafe.Pointer(cs))
 	if cErr != 0 {
-		return fmt.Errorf("failed to unpin program %s to %s: %s", p.name, path, syscall.Errno(int(-cErr)))
+		return fmt.Errorf("failed to unpin program %s to %s: %s", p.name, path, syscall.Errno(int(cErr)))
 	}
 	p.pinnedPath = ""
 	return nil
@@ -877,7 +877,7 @@ func (p *BPFProg) SetAutoload(autoload bool) error {
 	cbool := C.bool(autoload)
 	cErr := C.bpf_program__set_autoload(p.prog, cbool)
 	if cErr != 0 {
-		return fmt.Errorf("failed to set bpf program autoload: %s", syscall.Errno(int(-cErr)))
+		return fmt.Errorf("failed to set bpf program autoload: %s", syscall.Errno(int(cErr)))
 	}
 	return nil
 }
@@ -885,7 +885,7 @@ func (p *BPFProg) SetAutoload(autoload bool) error {
 func (p *BPFProg) SetTracepoint() error {
 	cErr := C.bpf_program__set_tracepoint(p.prog)
 	if cErr != 0 {
-		return fmt.Errorf("failed to set bpf program as tracepoint: %s", syscall.Errno(int(-cErr)))
+		return fmt.Errorf("failed to set bpf program as tracepoint: %s", syscall.Errno(int(cErr)))
 	}
 	return nil
 }


### PR DESCRIPTION
This handles correcting how we check errors in libbpfgo
in accordance with how libbpf recommends handling errors
leading into libbpf.

Particularly this follows the following rules:

- APIs that return an error code (int) should have
  error codes checked directly. The error codes
  correspond with error codes in the syscall package.

  For example:

  ```
  errCodeInt := C.libbpf_api_function()
  if errCodeInt != 0 {
    log.Errorf("uh oh: %s\n", syscall.Errno(errCodeInt))
  }
  ```

- APIs that return a pointer should be checked for
  NULL which indicates error. The error code is
  stored in errno. We can get the value of errno
  using the second return.

  For example:

  ```
  ptr, errno := C.libbpf_api_function()
  if ptr == nil {
    log.Errorf("uh oh: %s\n", errno)
  }
  ```

  We can also check if errno corresponds with a specific
  error (it implements the standard error interface).

  For example:

  ```
  ptr, errno := C.libbpf_api_function()
  if ptr == nil {
    if errno.Is(syscall.ENODENT) {
       // handle accordingly
    } else {
      log.Errorf("uh oh: %s\n", errno)
    }
  }

  ```

Signed-off-by: grantseltzer <grantseltzer@gmail.com>