### PR TITLE
0.6.1 fixes

### DIFF
--- a/libbpfgo_test.go
+++ b/libbpfgo_test.go
@@ -68,21 +68,7 @@ func Test_LoadAndAttach(t *testing.T) {
 			},
 		},
 		{
-			prog:      "kprobe__get_task_pid",
-			attachArg: "get_task_pid",
-			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
-				return prog.AttachKprobeLegacy(name)
-			},
-		},
-		{
-			prog:      "kretprobe__get_task_pid",
-			attachArg: "get_task_pid",
-			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
-				return prog.AttachKretprobeLegacy(name)
-			},
-		},
-		{
-			prog: "socket_connect",
+			prog:     "socket_connect",
 			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
 				if name != "" {
 					// to make the check for attaching with "foo" happy


### PR DESCRIPTION
commit d259d81
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Jan 25 16:36:22 2022

    libbpfgo: use perf_buffer__new new API and fix style

    Fix: #121

    This commit forces libbpfgo.go C embedded source code function
    init_perf_buf to use the new perf_buffer__new() API. This is needed to
    make sure libbpf doesn't choose to execute compatible perf_buffer__new()
    function prototype, causing execution issues (seg faults) in some
    environments.

commit 1a666df
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Jan 25 12:14:30 2022

    kprobe: remove legacy kprobes and unneeded includes

    Fix: #34

    Since libbpf commit 749b394 ("libbpf: Introduce legacy kprobe events
    support"), and subsequent fixes and refactorings to this code, there is
    no longer a need for libbpfgo to keep its own legacy kprobes code, as
    libbpfgo is now at libbpf v0.6.1 and that logic was added since v0.6.0.