### PR TITLE
Add version API

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -95,6 +95,21 @@ const (
 	maxEventChannels = 512
 )
 
+// MajorVersion returns the major semver version of libbpf.
+func MajorVersion() int {
+	return C.LIBBPF_MAJOR_VERSION
+}
+
+// MinorVersion returns the minor semver version of libbpf.
+func MinorVersion() int {
+	return C.LIBBPF_MINOR_VERSION
+}
+
+// VersionString returns the string representation of the libbpf version.
+func VersionString() string {
+	return fmt.Sprintf("v%d.%d", MajorVersion(), MinorVersion())
+}
+
 type Module struct {
 	obj      *C.struct_bpf_object
 	links    []*BPFLink


### PR DESCRIPTION
The new defines `LIBBPF_MAJOR_VERSION` and `LIBBPF_MINOR_VERSION` have
been introduced in libbpf v0.6. We now expose their API as well.
