### PR TITLE
Error handling fixes

### DIFF
--- a/selftest/error-handling/Makefile
+++ b/selftest/error-handling/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/error-handling/go.mod
+++ b/selftest/error-handling/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/map-update
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/error-handling/go.sum
+++ b/selftest/error-handling/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/error-handling/main.bpf.c
+++ b/selftest/error-handling/main.bpf.c
@@ -1,0 +1,11 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/error-handling/main.go
+++ b/selftest/error-handling/main.go
@@ -1,0 +1,59 @@
+package main
+
+import "C"
+
+import (
+	"errors"
+	"os"
+	"syscall"
+
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	bpfModule.BPFLoadObject()
+
+	// non-existant program
+	_, err = bpfModule.GetProgram("NewYorkYankeesRule")
+	if err == nil {
+		fmt.Fprintln(os.Stderr, "undetected error, non-existant program")
+		os.Exit(-1)
+	}
+	if !errors.Is(err, syscall.ENOENT) {
+		fmt.Fprintf(os.Stderr, "unexpected wrapped error received, expected ENOENT\n")
+		os.Exit(-1)
+	}
+
+	// non-existant map
+	_, err = bpfModule.GetMap("Ih8BostonRedSox")
+	if err == nil {
+		fmt.Fprintln(os.Stderr, "undetected error, non-existant map")
+		os.Exit(-1)
+	}
+	if !errors.Is(err, syscall.ENOENT) {
+		fmt.Fprintf(os.Stderr, "unexpected wrapped error received, expected ENOENT\n")
+		os.Exit(-1)
+	}
+
+	// invalid tc hook
+	tchook := bpfModule.TcHookInit()
+	err = tchook.Create()
+	if err == nil {
+		fmt.Fprintln(os.Stderr, "undetected error, invalid tchook create arguments")
+		os.Exit(-1)
+	}
+	if !errors.Is(err, syscall.EINVAL) {
+		fmt.Fprintf(os.Stderr, "unexpected wrapped error received, expected EINVAL\n")
+		os.Exit(-1)
+	}
+}

--- a/selftest/error-handling/run.sh
+++ b/selftest/error-handling/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh


### PR DESCRIPTION
This takes a simpler approach to error handling compare to previous PRs that were reverted. The conclusions I made are mainly that the macro `IS_ERR_OR_NULL` works well for backwards/forward compatibility. The APIs that return pointers will return NULL on error with error code in errno in the 1.0 libbpf release. Since this isn't yet consistent, it's better to just check if the return is NULL or if it contains the error code. 

The main changes here are getting more information out of directly returned error codes (non pointer APIs) using `syscall.Errno()`.

I also added a selftest which checks that error codes are properly handled in a few different API functions. If reviewers like this approach, i'll add more checks in that selftest before merging. 