### PR TITLE
helpers: Added dynamic symbol resolver

### DIFF
--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -6,19 +6,9 @@ import (
 	"fmt"
 )
 
-// SymbolToOffset attempts to resolve a 'symbol' name in the binary found at
-// 'path' to an offset. The offset can be used for attaching a u(ret)probe
-func SymbolToOffset(path, symbol string) (uint32, error) {
-	f, err := elf.Open(path)
-	if err != nil {
-		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %w", err)
-	}
-
-	syms, err := f.Symbols()
-	if err != nil {
-		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %w", err)
-	}
-
+// symbolToOffset attempts to resolve a 'symbol' name in the given binary to an offset.
+// The offset can be used for attaching a u(ret)probe.
+func symbolToOffset(symbol string, f *elf.File, syms []elf.Symbol) (uint32, error) {
 	sectionsToSearchForSymbol := []*elf.Section{}
 
 	for i := range f.Sections {
@@ -48,5 +38,37 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("symbol not found")
+	return 0, errors.New("symbol not found")
+}
+
+// SymbolToOffset attempts to resolve a 'symbol' name in the binary found at
+// 'path' to an offset. The offset can be used for attaching a u(ret)probe
+func SymbolToOffset(path, symbol string) (uint32, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %w", err)
+	}
+
+	syms, err := f.Symbols()
+	if err != nil {
+		return 0, fmt.Errorf("could not open symbol section to resolve symbol offset: %w", err)
+	}
+
+	return symbolToOffset(symbol, f, syms)
+}
+
+// DynamicSymbolToOffset attempts to resolve a dynamic 'symbol' name in the binary found at
+// 'path' to an offset. The offset can be used for attaching a u(ret)probe
+func DynamicSymbolToOffset(path, symbol string) (uint32, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %w", err)
+	}
+
+	syms, err := f.DynamicSymbols()
+	if err != nil {
+		return 0, fmt.Errorf("could not open dynamic symbol section to resolve symbol offset: %w", err)
+	}
+
+	return symbolToOffset(symbol, f, syms)
 }

--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -19,7 +19,7 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 
 	// Only if we failed getting both regular and dynamic symbols - then we abort.
 	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
-		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w", regularSymbolsErr)
+		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w, %w", regularSymbolsErr, dynamicSymbolsError)
 	}
 
 	// Concatenating into a single list.

--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -55,5 +55,5 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 		}
 	}
 
-	return 0, errors.New("symbol not found")
+	return 0, fmt.Errorf("symbol %s not found in %s", symbol, path)
 }

--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -19,7 +19,7 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 
 	// Only if we failed getting both regular and dynamic symbols - then we abort.
 	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
-		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w, %w", regularSymbolsErr, dynamicSymbolsError)
+		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w, %w", regularSymbolsErr, dynamicSymbolsErr)
 	}
 
 	// Concatenating into a single list.


### PR DESCRIPTION
Dynamic symbols are very important to attach u(ret)probe on common libraries such as openssl, libc, etc.

issue: https://github.com/aquasecurity/libbpfgo/issues/129