### PR TITLE
fix: if `lostChan` is `nil`, no need to close it

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -1111,7 +1111,9 @@ func (pb *PerfBuffer) Stop() {
 		// Close the channel -- this is useful for the consumer but
 		// also to terminate the drain goroutine above.
 		close(pb.eventsChan)
-		close(pb.lostChan)
+		if pb.lostChan != nil {
+			close(pb.lostChan)
+		}
 
 		// This allows Stop() to be called multiple times safely
 		pb.stop = nil


### PR DESCRIPTION
There are cases in which it is `lostChan` arguments is `nil` in called `initPerfBuf()`. In this case, calling `perfBuffer.Stop()` will close `nil` and panic.

In this PR, if `lostChan` is `nil`, not close it.


```go
func main() {
        ...
        e := make(chan []byte, 300)
        p, err := bpfModule.InitPerfBuf("events", e, nil, 1024)
        p.Start()
        ...
        <-sig
        p.Stop() // panic: close of nil channel
}
```

The panic error message is as follows:

```
panic: close of nil channel
        panic: close of closed channel

goroutine 1 [running]:
github.com/aquasecurity/libbpfgo.(*PerfBuffer).Stop(0xc0000e4000)
        /tmp/app/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go:1018 +0x36
github.com/aquasecurity/libbpfgo.(*PerfBuffer).Close(0xc0000e4000)
        /tmp/app/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go:1051 +0x2e
github.com/aquasecurity/libbpfgo.(*Module).Close(0xc0000de000)
        /tmp/app/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go:334 +0x45
panic({0x4ca640, 0x4f8f80})
        /usr/lib/go-1.17/src/runtime/panic.go:1038 +0x215
github.com/aquasecurity/libbpfgo.(*PerfBuffer).Stop(0xc0000e4000)
        /tmp/app/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go:1040 +0xa5
main.main()
        /tmp/app/main.go:50 +0x26f
```

https://github.com/aquasecurity/libbpfgo/blob/c46f053c16e763c717de89fa4540cc0975de1865/libbpfgo.go#L1114
