### PR TITLE
Fix error handling in helper function

### DIFF
--- a/helpers/elf.go
+++ b/helpers/elf.go
@@ -18,11 +18,8 @@ func SymbolToOffset(path, symbol string) (uint32, error) {
 	dynamicSymbols, dynamicSymbolsErr := f.DynamicSymbols()
 
 	// Only if we failed getting both regular and dynamic symbols - then we abort.
-	if regularSymbolsErr != nil {
-		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w", regularSymbolsErr)
-	}
-	if dynamicSymbolsErr != nil {
-		return 0, fmt.Errorf("could not open symbol sections to resolve symbol offset: %w", dynamicSymbolsErr)
+	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
+		return 0, fmt.Errorf("could not open regular or dynamic symbol sections to resolve symbol offset: %w %s", regularSymbolsErr, dynamicSymbolsErr)
 	}
 
 	// Concatenating into a single list.


### PR DESCRIPTION
As the comment that's been there explains, we only need one symbols section.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>