### PR TITLE
Spinlock selftest

### DIFF
--- a/selftest/spinlocks/Makefile
+++ b/selftest/spinlocks/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/spinlocks/README.md
+++ b/selftest/spinlocks/README.md
@@ -1,0 +1,12 @@
+# Spinlocks
+
+https://lwn.net/Articles/776909/
+
+In BTF annotated BPF maps, we can use a bpf_spin_lock to allow for atomic reads/updates of values in BPF maps.
+
+It is NOT supported in programs of type:
+
+- BPF_PROG_TYPE_KPROBE
+- BPF_PROG_TYPE_TRACEPOINT
+- BPF_PROG_TYPE_PERF_EVENT
+- BPF_PROG_TYPE_RAW_TRACEPOINT

--- a/selftest/spinlocks/go.mod
+++ b/selftest/spinlocks/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/perfbuffers
+
+go 1.16
+
+require github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/spinlocks/go.sum
+++ b/selftest/spinlocks/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/spinlocks/main.bpf.c
+++ b/selftest/spinlocks/main.bpf.c
@@ -1,0 +1,58 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>  
+
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
+#define VAR_NUM 16
+
+struct hmap_elem {
+	struct bpf_spin_lock lock;
+	int val;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct hmap_elem);
+} counter_hash_map SEC(".maps");
+
+long ringbuffer_flags = 0;
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 24);
+} events SEC(".maps");
+
+SEC("fentry/__x64_sys_mmap")
+int mmap_fentry(struct pt_regs *ctx)
+{
+    int *process;
+    struct hmap_elem *lost_event_counter;
+    int key = 1;
+
+    lost_event_counter = bpf_map_lookup_elem(&counter_hash_map, &key);
+    if (!lost_event_counter) {
+        return 0;
+    }
+
+    // Reserve space on the ringbuffer for the sample
+    process = bpf_ringbuf_reserve(&events, sizeof(int), ringbuffer_flags);
+    if (!process) {
+
+        bpf_spin_lock(&lost_event_counter->lock);
+        lost_event_counter->val++;
+        bpf_spin_unlock(&lost_event_counter->lock);
+        return 0;
+    }
+
+    *process = 2021;
+
+    bpf_ringbuf_submit(process, ringbuffer_flags);
+    return 0;
+}
+char LICENSE[] SEC("license") = "GPL";

--- a/selftest/spinlocks/main.go
+++ b/selftest/spinlocks/main.go
@@ -1,0 +1,120 @@
+package main
+
+import "C"
+
+import (
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"encoding/binary"
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func resizeMap(module *bpf.Module, name string, size uint32) error {
+	m, err := module.GetMap("events")
+	if err != nil {
+		return err
+	}
+
+	if err = m.Resize(size); err != nil {
+		return err
+	}
+
+	if actual := m.GetMaxEntries(); actual != size {
+		return fmt.Errorf("map resize failed, expected %v, actual %v", size, actual)
+	}
+
+	return nil
+}
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	err = bpfModule.BPFLoadObject()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	bpfModule.ListProgramNames()
+
+	prog, err := bpfModule.GetProgram("mmap_fentry")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	link, err := prog.AttachGeneric()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	if link.GetFd() == 0 {
+		os.Exit(-1)
+	}
+
+	eventsChannel := make(chan []byte)
+	rb, err := bpfModule.InitRingBuf("events", eventsChannel)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	lostEventCounterMap, err := bpfModule.GetMap("counter_hash_map")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	var lostEventCounterKey uint32 = 1
+	var zero uint32
+	lostEventCounterMap.Update(unsafe.Pointer(&lostEventCounterKey), unsafe.Pointer(&zero))
+
+	rb.Start()
+
+	numberOfEventsReceived := 0
+	go func() {
+		for {
+			syscall.Mmap(999, 999, 999, 1, 1)
+			time.Sleep(time.Second / 2)
+		}
+	}()
+recvLoop:
+	for {
+		b := <-eventsChannel
+		if binary.LittleEndian.Uint32(b) != 2021 {
+			fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+			os.Exit(-1)
+		}
+		numberOfEventsReceived++
+		if numberOfEventsReceived > 5 {
+			break recvLoop
+		}
+	}
+
+	rb.Stop()
+	rb.Close()
+
+	val, err := lostEventCounterMap.GetValue(unsafe.Pointer(&lostEventCounterKey))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	fmt.Println("lost events = ", val)
+}

--- a/selftest/spinlocks/run.sh
+++ b/selftest/spinlocks/run.sh
@@ -1,0 +1,1 @@
+../common/run-5.8.sh


### PR DESCRIPTION
This adds a selftest for spinlock functionality. This uses it for updating a counter in lost event logic for ringbuffers, but I don't think this is the best approach for that usecase. I plan on doing a writeup on alternatives.  

Signed-off-by: grantseltzer <grantseltzer@gmail.com>