### PR TITLE
Fixes for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ SELFTEST = ./selftest
 
 CC = gcc
 CLANG = clang
+GO = go
 
-ARCH := $(shell uname -m)
-ARCH := $(subst x86_64,amd64,$(ARCH))
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
 
 BTFFILE = /sys/kernel/btf/vmlinux
 BPFTOOL = $(shell which bpftool || /bin/false)
@@ -55,13 +55,13 @@ libbpfgo-dynamic: $(OUTPUT)/libbpf
 	CC=$(CLANG) \
 		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
-		go build .
+		$(GO) build .
 
 libbpfgo-dynamic-test: libbpfgo-test-bpf-dynamic
 	CC=$(CLANG) \
 		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
-		sudo -E go test .
+		sudo -E $(GO) test .
 
 # libbpf: static
 
@@ -70,7 +70,7 @@ libbpfgo-static: $(VMLINUXH) | $(LIBBPF_OBJ)
 		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
 		GOOS=linux GOARCH=$(ARCH) \
-		go build \
+		$(GO) build \
 		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
 		.
 
@@ -80,7 +80,7 @@ libbpfgo-static-test: libbpfgo-test-bpf-static
 		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
 		GOOS=linux GOARCH=$(ARCH) \
-		go test \
+		$(GO) test \
 		-v -tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
 		.
 

--- a/selftest/build/Makefile
+++ b/selftest/build/Makefile
@@ -7,6 +7,7 @@ CLANG = clang
 
 CFLAGS = -g -O2 -Wall -fpie
 LDFLAGS =
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
 
 TEST = libbpfgo_test
 
@@ -24,7 +25,7 @@ vmlinuxh: outputdir
 
 $(TEST).bpf.o: $(TEST).bpf.c
 	$(MAKE) -C $(BASEDIR) vmlinuxh
-	$(CLANG) $(CFLAGS) -target bpf -I$(OUTPUT) -c $< -o $@
+	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH) -I$(OUTPUT) -c $< -o $@
 
 ## clean
 

--- a/selftest/common/Makefile
+++ b/selftest/common/Makefile
@@ -7,9 +7,9 @@ LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
 
 CC = gcc
 CLANG = clang
+GO = go
 
-ARCH := $(shell uname -m)
-ARCH := $(subst x86_64,amd64,$(ARCH))
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
 
 CFLAGS = -g -O2 -Wall -fpie
 LDFLAGS =
@@ -51,7 +51,7 @@ outputdir:
 
 $(TEST).bpf.o: $(TEST).bpf.c
 	$(MAKE) -C $(BASEDIR) vmlinuxh
-	$(CLANG) $(CFLAGS) -target bpf -I$(OUTPUT) -c $< -o $@
+	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH) -I$(OUTPUT) -c $< -o $@
 
 ## test
 
@@ -63,7 +63,7 @@ $(TEST)-static: libbpfgo-static | $(TEST).bpf.o
 		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
 		GOOS=linux GOARCH=$(ARCH) \
-		go build \
+		$(GO) build \
 		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
 		-o $(TEST)-static ./$(TEST).go
 
@@ -71,7 +71,7 @@ $(TEST)-dynamic: libbpfgo-dynamic | $(TEST).bpf.o
 	CC=$(CLANG) \
 		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
-		go build -o ./$(TEST)-dynamic ./$(TEST).go
+		$(GO) build -o ./$(TEST)-dynamic ./$(TEST).go
 
 ## run
 

--- a/selftest/tcpconnect/Makefile
+++ b/selftest/tcpconnect/Makefile
@@ -7,8 +7,10 @@ LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
 
 CC = gcc
 CLANG = clang
+GO = go
 
-ARCH = x86
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
+
 GOARCH = amd64
 
 BPFTOOL = $(shell which bpftool || /bin/false)
@@ -70,7 +72,7 @@ $(TEST)-static: libbpfgo-static | $(TEST).bpf.o
 		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
 		GOARCH=$(GOARCH) \
-		go build \
+		$(GO) build \
 		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
 		-o $(TEST)-static ./$(TEST).go
 
@@ -78,7 +80,7 @@ $(TEST)-dynamic: libbpfgo-dynamic | $(TEST).bpf.o
 	CC=$(CLANG) \
 		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
 		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
-		go build -o ./$(TEST)-dynamic ./$(TEST).go
+		$(GO) build -o ./$(TEST)-dynamic ./$(TEST).go
 
 ## clean
 

--- a/selftest/uprobe/Makefile
+++ b/selftest/uprobe/Makefile
@@ -10,6 +10,7 @@ CLANG = clang
 
 CFLAGS = -g -O2 -Wall -fpie
 LDFLAGS =
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
 
 CGO_CFLAGS_STATIC = "-I$(abspath $(OUTPUT))"
 CGO_LDFLAGS_STATIC = "-lelf -lz $(LIBBPF_OBJ)"
@@ -45,7 +46,7 @@ vmlinuxh:
 .PHONY: $(TEST)-bpf
 
 $(TEST)-bpf: vmlinuxh
-	$(CLANG) $(CFLAGS) -target bpf -I$(OUTPUT) -c $(TEST).bpf.c -o $(TEST).bpf.o
+	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH) -I$(OUTPUT) -c $(TEST).bpf.c -o $(TEST).bpf.o
 
 ## test deps
 
@@ -60,7 +61,7 @@ ctest:
 .PHONY: gotest
 gotest:
 	@if [ ! -x ctest ]; then \
-		go build -o gotest test.go; \
+		$(GO) build -o gotest test.go; \
 	 fi
 
 ## test
@@ -70,11 +71,11 @@ gotest:
 
 $(TEST)-static: $(TEST)-bpf libbpfgo-static $(DEPS)
 	CC=$(CLANG) CGO_CFLAGS=$(CGO_CFLAGS_STATIC) CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
-	   go build -o $(TEST)-static ./$(TEST).go
+	   $(GO) build -o $(TEST)-static ./$(TEST).go
 
 $(TEST)-dynamic: $(TEST)-bpf libbpfgo-dynamic $(DEPS)
 	CC=$(CLANG) CGO_CFLAGS=$(CGO_CFLAGS_DYN) CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
-	   go build -o ./$(TEST)-dynamic ./$(TEST).go
+	   $(GO) build -o ./$(TEST)-dynamic ./$(TEST).go
 
 ## run
 


### PR DESCRIPTION
On my dev machine:
```
$ uname -m
arm64
```

This PR addresses this and creates a `GO` Make variable to make it easy to
override while trying golang binaries in non-standard paths

**Test plan**
```
$ sudo make GO=/usr/local/go/bin/go run-dynamic
[...]
sudo ./run.sh main-dynamic
[*] SUCCESS: all good
```

cc/ @Sylfrena @v-thakkar @kakkoyun