### PR TITLE
libbpfgo: mitigate tc error messages

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -36,6 +36,16 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
     if (level != LIBBPF_WARN)
         return 0;
 
+	// BUG: https://github.com/aquasecurity/tracee/issues/1676
+
+	va_list check; va_copy(check, args);
+	char *str = va_arg(check, char *);
+	if (strstr(str, "Exclusivity flag on") != NULL) {
+		va_end(check);
+		return 0;
+	}
+	va_end(check);
+
     return vfprintf(stderr, format, args);
 }
 


### PR DESCRIPTION
This is a workaround for the following issue:

$ sudo ./dist/tracee-ebpf -o format:json -o option:parse-arguments -o
    option:detect-syscall -trace comm=bash -trace follow -trace
    event=net_packet -trace net=docker0 -capture net=docker0

libbpf: Kernel error message: Exclusivity flag on, cannot modify
libbpf: Kernel error message: Exclusivity flag on, cannot modify

Discussed at https://www.spinics.net/lists/bpf/msg44842.html without
conclusions.