### PR TITLE
Remove ListProgramNames API

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -70,18 +70,6 @@ struct ring_buffer * init_ring_buf(int map_fd, uintptr_t ctx)
     return rb;
 }
 
-void list_programs(struct bpf_object* obj) {
-	struct bpf_program *pos;
-	const char *cs;
-	const char *css;
-
-	bpf_object__for_each_program(pos, obj) {
-		cs = bpf_program__section_name(pos);
-		css = bpf_program__name(pos);
-		printf("section: %s\tname: %s\n", cs, css);
-	}
-}
-
 struct perf_buffer * init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx)
 {
     struct perf_buffer_opts pb_opts = {};
@@ -1084,10 +1072,6 @@ func (m *Module) GetProgram(progName string) (*BPFProg, error) {
 		prog:   prog,
 		module: m,
 	}, nil
-}
-
-func (m *Module) ListProgramNames() {
-	C.list_programs(m.obj)
 }
 
 func (p *BPFProg) GetFd() int {

--- a/samples/fentry/main.go
+++ b/samples/fentry/main.go
@@ -25,7 +25,6 @@ func main() {
 		os.Exit(-1)
 	}
 
-	bpfModule.ListProgramNames()
 	prog1, err := bpfModule.GetProgram("commit_creds")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/selftest/set-attach/main.go
+++ b/selftest/set-attach/main.go
@@ -22,8 +22,6 @@ func main() {
 	}
 	defer bpfModule.Close()
 
-	bpfModule.ListProgramNames()
-
 	prog, err := bpfModule.GetProgram("foobar")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This API function relies on a `printf()` call in C code, which I was using for debugging purposes. It shouldn't be included in the upcoming release so I'm removing it. 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>