### PR TITLE
Move RWArray helpers into own package

### DIFF
--- a/helpers/rwarray/rwArray.go
+++ b/helpers/rwarray/rwArray.go
@@ -1,4 +1,4 @@
-package helpers
+package rwarray
 
 import (
 	"sync"

--- a/helpers/rwarray/rwArray_test.go
+++ b/helpers/rwarray/rwArray_test.go
@@ -1,4 +1,4 @@
-package helpers
+package rwarray
 
 import (
 	"sync"

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -98,7 +98,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/aquasecurity/libbpfgo/helpers"
+	"github.com/aquasecurity/libbpfgo/helpers/rwarray"
 )
 
 const (
@@ -1501,7 +1501,7 @@ func doAttachUprobe(prog *BPFProg, isUretprobe bool, pid int, path string, offse
 	return bpfLink, nil
 }
 
-var eventChannels = helpers.NewRWArray(maxEventChannels)
+var eventChannels = rwarray.NewRWArray(maxEventChannels)
 
 func (m *Module) InitRingBuf(mapName string, eventsChan chan []byte) (*RingBuffer, error) {
 	bpfMap, err := m.GetMap(mapName)


### PR DESCRIPTION
The RWArray is the only part of the helpers package
that was previous used within the libbpfgo package.
This presents an issue when the helpers package wants
to import libbpfgo (creates a circular dependency)

Moving RWArray to a different package solves this issue.

In general, helpers should be able to import libbpfgo but
libbpfgo should not import helpers

Signed-off-by: grantseltzer <grantseltzer@gmail.com>