### PR TITLE
make: workflow: doc: add helpers tests rules

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,8 @@ jobs:
         with:
           go-version: 1.18
       - name: Test Helpers
-        run: go test ./helpers
+        run: |
+          make helpers-test-static-run
   self-tests:
     name: Selftests
     runs-on: ubuntu-20.04
@@ -30,4 +31,4 @@ jobs:
           go-version: 1.18
       - name: Static Selftests
         run: |
-          sudo make selftest-static-run
+          make selftest-static-run

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BASEDIR = $(abspath ./)
 
 OUTPUT = ./output
 SELFTEST = ./selftest
+HELPERS = ./helpers
 
 CC = gcc
 CLANG = clang
@@ -161,6 +162,23 @@ selftest-dynamic-run:
 
 selftest-clean:
 	$(call FOREACH, clean)
+
+# helpers test
+
+.PHONY: helpers-test-run
+.PHONY: helpers-test-static-run
+.PHONY: helpers-test-dynamic-run
+
+helpers-test-run: helpers-test-static-run
+
+helpers-test-static-run: libbpfgo-static
+	CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
+		sudo $(GO) test -v $(HELPERS)/...
+
+helpers-test-dynamic-run: libbpfgo-dynamic
+	sudo $(GO) test -v $(HELPERS)/...
 
 # output
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ Currently you will find the following GNU Makefile rules:
 | clean                    | cleans entire tree                |
 | selftest                 | builds all selftests (static)     |
 | selftest-run             | runs all selftests (static)       |
+| helpers-test-run         | runs all helpers tests (static)   |
 
 * libbpf dynamically linked (libbpf from OS)
 
@@ -47,6 +48,7 @@ Currently you will find the following GNU Makefile rules:
 | libbpfgo-dynamic-test    | 'go test' with dynamic libbpfgo   |
 | selftest-dynamic         | build tests with dynamic libbpfgo |
 | selftest-dynamic-run     | run tests using dynamic libbpfgo  |
+| helpers-test-dynamic-run | run tests using dynamic libbpfgo  |
 
 * statically compiled (libbpf submodule)
 
@@ -56,6 +58,7 @@ Currently you will find the following GNU Makefile rules:
 | libbpfgo-static-test     | 'go test' with static libbpfgo    |
 | selftest-static          | build tests with static libbpfgo  |
 | selftest-static-run      | run tests using static libbpfgo   |
+| helpers-test-static-run  | run tests using static libbpfgo   |
 
 * examples
 

--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,7 @@ Currently you will find the following GNU Makefile rules:
 | libbpfgo-dynamic-test    | 'go test' with dynamic libbpfgo   |
 | selftest-dynamic         | build tests with dynamic libbpfgo |
 | selftest-dynamic-run     | run tests using dynamic libbpfgo  |
-| helpers-test-dynamic-run | run tests using dynamic libbpfgo  |
+| helpers-test-dynamic-run | run helpers package unit tests using dynamic libbpfgo  |
 
 * statically compiled (libbpf submodule)
 
@@ -58,7 +58,7 @@ Currently you will find the following GNU Makefile rules:
 | libbpfgo-static-test     | 'go test' with static libbpfgo    |
 | selftest-static          | build tests with static libbpfgo  |
 | selftest-static-run      | run tests using static libbpfgo   |
-| helpers-test-static-run  | run tests using static libbpfgo   |
+| helpers-test-static-run  | run helpers package unit tests using static libbpfgo   |
 
 * examples
 


### PR DESCRIPTION
Introduce Makefile helpers-test-run (helpers-test-static-run) and helpers-test-dynamic-run rules.

Update pr.yaml workflow and Readme.md.

Fix lack of static compilation in pr.yaml workflow: https://github.com/aquasecurity/libbpfgo/runs/7789288488?check_suite_focus=true

Tested:

https://github.com/geyslan/libbpfgo/actions/runs/2850068323

https://github.com/geyslan/libbpfgo/actions/runs/2850285441

https://github.com/geyslan/libbpfgo/actions/runs/2850302102

![image](https://user-images.githubusercontent.com/3372117/184463773-7e632780-7640-4b17-8685-557b637f2810.png)



