### PR TITLE
Fix undefined behaviour in variadic argument handling

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -48,12 +48,17 @@ int libbpf_print_fn(enum libbpf_print_level level,
 	}
 
 	va_end(cgroup_check);
-	// `args` is initialised and cleared in the call-site [1], as per the UNIX
-	// spec [2]:
+	// `args` is initialised and cleared in the call-site [1], as per the specs:
+	// [2]:
+	// > Each invocation of va_start() must be matched by a corresponding
+	// > invocation of va_end() in the same function. After the call
+	// > va_end(ap) the variable ap is undefined.
+	// [3]:
 	// > Corresponding va_start() and va_end() macro calls must be in the same function.
 	//
 	// [1]: https://github.com/libbpf/libbpf/blob/a0d1e22c7790f22809d33b3c5c1e3ded89157cc8/src/libbpf.c#L233-L235
-	// [2]: https://www.ibm.com/docs/en/zos/2.3.0?topic=lf-va-arg-va-copy-va-end-va-start-access-function-arguments
+	// [2]: https://man7.org/linux/man-pages/man3/va_arg.3.html
+	// [3]: https://www.ibm.com/docs/en/zos/2.3.0?topic=lf-va-arg-va-copy-va-end-va-start-access-function-arguments
 	return vfprintf(stderr, format, args);
 }
 


### PR DESCRIPTION
We were seeing some crashes in Parca Agent (https://github.com/parca-dev/parca-agent/issues/817) when running on libbpfgo `v0.4.0-libbpf-1.0.0`.

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3c pc=0x18724f1]

runtime stack:
runtime.throw({0x1da3dc1?, 0x0?})
	runtime/panic.go:992 +0x71
runtime.sigpanic()
	runtime/signal_unix.go:802 +0x3a9
[...]
```

Under gdb, the top of the stack seemed to be around the libbpf printing facilities:

```
(gdb) bt
#0  0x00000000018724f1 in __strstr_sse2_unaligned ()
#1  0x00000000017c4156 in libbpf_print_fn ()
#2  0x00000000017cb31c in libbpf_print (level=(unknown: 0x3c), level@entry=LIBBPF_WARN, format=0x205ad64 "cgroup") at libbpf.c:103
#3  0x00000000017debc7 in bpf_object__init_user_maps (obj=0x7fff9c0012a0, strict=<optimized out>) at libbpf.c:2004
#4  bpf_object__init_maps (obj=obj@entry=0x7fff9c0012a0, opts=opts@entry=0xc0000fe280) at libbpf.c:2617
#5  0x00000000017cdfe7 in bpf_object_open (path=<optimized out>, path@entry=0x0, obj_buf=0x7fff9c000b90, obj_buf_sz=1792, opts=0xc0000fe280) at libbpf.c:7410
#6  0x00000000017ce1ad in bpf_object__open_mem (obj_buf=0x205ad64, obj_buf_sz=103, opts=0x7fffa6ffbd50) at libbpf.c:7472
#7  0x00000000017c49f4 in _cgo_b2805b411fbe_C2func_bpf_object__open_mem ()
#8  0x000000000046c924 in runtime.asmcgocall () at runtime/asm_amd64.s:821
#9  0x0000000000000004 in ?? ()
#10 0x000000c00063a7d0 in ?? ()
#11 0x0000000000000001 in ?? ()
#12 0x0000000000000000 in ?? ()
```

Which led me to the variadic arguments being reused after iterating over them. Also added the missing `va_end`s  before returning, as per the UNIX spec

> Corresponding va_start() and va_end() macro calls must be in the same function.

https://www.ibm.com/docs/en/zos/2.3.0?topic=lf-va-arg-va-copy-va-end-va-start-access-function-arguments

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>