### PR TITLE
Redefine BPFProgType constants and remove libbpfgo import

### DIFF
--- a/helpers/argumentParsers_test.go
+++ b/helpers/argumentParsers_test.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"testing"
 
-	"github.com/aquasecurity/libbpfgo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,7 +157,7 @@ func TestParseBPFProgType(t *testing.T) {
 	}{
 		{
 			name:          "Type tracepoint",
-			parseValue:    libbpfgo.BPFProgTypeTracepoint.Value(),
+			parseValue:    BPFProgTypeTracepoint.Value(),
 			expectedSting: "BPF_PROG_TYPE_TRACEPOINT",
 			expectedError: false,
 		},

--- a/helpers/go.mod
+++ b/helpers/go.mod
@@ -3,7 +3,6 @@ module github.com/aquasecurity/libbpfgo/helpers
 go 1.18
 
 require (
-	github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20221004153638-7139cb41036f
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
 )

--- a/helpers/go.sum
+++ b/helpers/go.sum
@@ -1,5 +1,3 @@
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20221004153638-7139cb41036f h1:8vfY/LaTk096KJ6pi6IdOzIIjZxQqP/jhH4CtZ4rM7I=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20221004153638-7139cb41036f/go.mod h1:BUFy1KtlXJD5rWElGW+jOl3FD167uDx9+02zIuH2v1A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This completely removes dependence between either helpers or libbpfgo

Signed-off-by: grantseltzer <grantseltzer@gmail.com>