### PR TITLE
Fix access violation in libbpf_print_fn.

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -11,40 +11,43 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
-int libbpf_print_fn(enum libbpf_print_level level, const char *format,
-                    va_list args) {
+int libbpf_print_fn(enum libbpf_print_level level,
+                    const char *format,
+                    va_list args)
+{
   if (level != LIBBPF_WARN)
     return 0;
 
-  // NOTE: va_list args is managed in libbpf caller
-  // however, these copies must be matched with va_end() in this function
-  va_list exclusivity_check, cgroup_check;
-  va_copy(exclusivity_check, args);
-  va_copy(cgroup_check, args);
+  char str[300];
+  va_list check;
+  int ret;
+
+  va_copy(check, args);
+  ret = vsnprintf(str, sizeof(str), format, check);
+  va_end(args);
+
+  // vsnprintf failed for whatever reason. We need
+  // to skip checking.
+  if (ret <= 0) {
+    goto Done;
+  }
 
   // BUG: https://github.com/aquasecurity/tracee/issues/1676
 
-  char *str = va_arg(exclusivity_check, char *);
   if (strstr(str, "Exclusivity flag on") != NULL) {
-    va_end(exclusivity_check);
     return 0;
   }
-  va_end(exclusivity_check);
 
   // AttachCgroupLegacy() will first try AttachCgroup() and it
   // might fail. This is not an error and is the best way of
   // probing for eBPF cgroup attachment link existence.
 
-  str = va_arg(cgroup_check, char *);
   if (strstr(str, "cgroup") != NULL) {
-    str = va_arg(cgroup_check, char *);
-    if (strstr(str, "Invalid argument") != NULL) {
-      va_end(cgroup_check);
+    if (strstr(str, "Invalid argument") != NULL)
       return 0;
-    }
   }
-  va_end(cgroup_check);
 
+Done:
   return vfprintf(stderr, format, args);
 }
 

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -11,10 +11,8 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
-int libbpf_print_fn(enum libbpf_print_level level,
-                    const char *format,
-                    va_list args)
-{
+int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+                    va_list args) {
   if (level != LIBBPF_WARN)
     return 0;
 


### PR DESCRIPTION
libbpf_print_fn uses va_arg and explicit argument type "char*" to retrieve arguments as strings. This assumption is incorrect. In case when libbpf logs a printf format string with argument being a non-string type, the str pointer will point to memory that is not NULL terminated. Wnen strstr is called with a non-NULL terminated string, we hit access violation on the stack.

This change uses a temporary string allocated on the stack to be filled with a printf formatted string with the arguments converted into the string. The keywords search are performed on the temporary string buffer.

Fix: #272 

Signed-off-by: Hao Xiang <haoxiang@bytedance.com>