### PR TITLE
Add `SetPrintLevel` to support changing print level of libbpf messages

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -314,6 +314,18 @@ func SetStrictMode(mode LibbpfStrictMode) {
 	C.libbpf_set_strict_mode(uint32(mode))
 }
 
+type LibbpfPrintLevel uint32
+
+const (
+	LibbpfPrintLevelWarn  = C.LIBBPF_WARN
+	LibbpfPrintLevelInfo  = C.LIBBPF_INFO
+	LibbpfPrintLevelDebug = C.LIBBPF_DEBUG
+)
+
+func SetPrintLevel(level LibbpfPrintLevel) {
+	C.set_libbpf_print_min_level(uint32(level))
+}
+
 func NewModuleFromFileArgs(args NewModuleArgs) (*Module, error) {
 	f, err := elf.Open(args.BPFObjPath)
 	if err != nil {

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -323,7 +323,7 @@ const (
 )
 
 func SetPrintLevel(level LibbpfPrintLevel) {
-	C.set_libbpf_print_min_level(uint32(level))
+	C.set_libbpf_print_max_level(uint32(level))
 }
 
 func NewModuleFromFileArgs(args NewModuleArgs) (*Module, error) {

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -317,9 +317,9 @@ func SetStrictMode(mode LibbpfStrictMode) {
 type LibbpfPrintLevel uint32
 
 const (
-	LibbpfPrintLevelWarn  = C.LIBBPF_WARN
-	LibbpfPrintLevelInfo  = C.LIBBPF_INFO
-	LibbpfPrintLevelDebug = C.LIBBPF_DEBUG
+	LibbpfPrintLevelWarn  LibbpfPrintLevel = C.LIBBPF_WARN
+	LibbpfPrintLevelInfo  LibbpfPrintLevel = C.LIBBPF_INFO
+	LibbpfPrintLevelDebug LibbpfPrintLevel = C.LIBBPF_DEBUG
 )
 
 func SetPrintLevel(level LibbpfPrintLevel) {

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -11,11 +11,11 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
-enum libbpf_print_level min_level = LIBBPF_WARN;
+enum libbpf_print_level max_level = LIBBPF_WARN;
 
 int libbpf_print_fn(enum libbpf_print_level level, const char *format,
                     va_list args) {
-  if (level > min_level)
+  if (level > max_level)
     return 0;
 
   // NOTE: va_list args is managed in libbpf caller
@@ -51,8 +51,8 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 }
 
 void set_print_fn() { libbpf_set_print(libbpf_print_fn); }
-void set_libbpf_print_min_level(enum libbpf_print_level level) {
-  min_level = level;
+void set_libbpf_print_max_level(enum libbpf_print_level level) {
+  max_level = level;
 }
 
 extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -51,7 +51,9 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 }
 
 void set_print_fn() { libbpf_set_print(libbpf_print_fn); }
-void set_libbpf_print_min_level(enum libbpf_print_level level) { min_level = level; }
+void set_libbpf_print_min_level(enum libbpf_print_level level) {
+  min_level = level;
+}
 
 extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);
 extern void perfLostCallback(void *ctx, int cpu, __u64 cnt);

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -11,9 +11,11 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
+enum libbpf_print_level min_level = LIBBPF_WARN;
+
 int libbpf_print_fn(enum libbpf_print_level level, const char *format,
                     va_list args) {
-  if (level != LIBBPF_WARN)
+  if (level > min_level)
     return 0;
 
   // NOTE: va_list args is managed in libbpf caller
@@ -49,6 +51,7 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 }
 
 void set_print_fn() { libbpf_set_print(libbpf_print_fn); }
+void set_libbpf_print_min_level(enum libbpf_print_level level) { min_level = level; }
 
 extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);
 extern void perfLostCallback(void *ctx, int cpu, __u64 cnt);


### PR DESCRIPTION
Closes #6 

Depend on https://github.com/aquasecurity/libbpfgo/pull/270