### PR TITLE
libbpf: fix access violation in libbpf_print_fn.

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -35,6 +35,12 @@ int libbpf_print_fn(enum libbpf_print_level level, // libbpf print level
     return 0;
   }
 
+  // BUG: https://github.com/aquasecurity/tracee/issues/2446
+  if (strstr(str, "failed to create kprobe") != NULL) {
+    if (strstr(str, "trace_check_map_func_compatibility") != NULL)
+      return 0;
+  }
+
   // AttachCgroupLegacy() will first try AttachCgroup() and it might fail. This
   // is not an error and is the best way of probing for eBPF cgroup attachment
   // link existence.

--- a/selftest/spinlocks/main.go
+++ b/selftest/spinlocks/main.go
@@ -51,7 +51,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	bpfModule.ListProgramNames()
+	//bpfModule.ListProgramNames()
 
 	prog, err := bpfModule.GetProgram("mmap_fentry")
 	if err != nil {


### PR DESCRIPTION
libbpf_print_fn uses va_arg and explicit argument type "char*" to retrieve arguments as strings. This assumption is incorrect.  In case when libbpf logs a printf format string with argument being a non-string type, the str pointer will point to memory that is not NULL terminated. Wnen strstr is called with a non-NULL terminated string, we hit access violation on the stack.

This change uses a temporary string allocated on the stack to be filled with a printf formatted string with the arguments converted into the string. The keywords search are performed on the temporary string buffer.

Signed-off-by: Hao Xiang <haoxiang@bytedance.com>