### PR TITLE
makefile: turn libbpfgo-static into default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ CGO_LDFLAGS_DYN = "-lelf -lz -lbpf"
 
 # default == shared lib from OS package
 
-all: libbpfgo-dynamic
-test: libbpfgo-dynamic-test
+all: libbpfgo-static
+test: libbpfgo-static-test
 
 # libbpfgo test object
 


### PR DESCRIPTION
Some environments might not have libbpf-devel installed, for example, and in those environments "make all" fails with missing bpf/bpf.h. Turn the static build the default one, which makes more sense.