### PR TITLE
logger callbacks

### DIFF
--- a/logger_cb.go
+++ b/logger_cb.go
@@ -1,0 +1,148 @@
+package libbpfgo
+
+/*
+#include <bpf/libbpf.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// This callback definition needs to be in a different file from where it is declared in C
+// Otherwise, multiple definition compilation error will occur
+
+// loggerCallback is called by libbpf_print_fn() which in turn is called by libbpf
+//
+//export loggerCallback
+func loggerCallback(libbpfPrintLevel int, libbpfOutput *C.char) {
+	var (
+		level    int
+		goOutput string
+	)
+
+	goOutput = C.GoString(libbpfOutput)
+	goOutput = strings.TrimSuffix(goOutput, "\n")
+
+	for _, fnFilterOut := range callbacks.LogFilters {
+		if fnFilterOut != nil {
+			if fnFilterOut(libbpfPrintLevel, goOutput) {
+				return
+			}
+		}
+	}
+
+	callbacks.Log(level, goOutput)
+}
+
+const (
+	// libbpf print levels
+	LibbpfWarnLevel  = int(C.LIBBPF_WARN)
+	LibbpfInfoLevel  = int(C.LIBBPF_INFO)
+	LibbpfDebugLevel = int(C.LIBBPF_DEBUG)
+)
+
+// Callbacks stores the callbacks to be used by libbpfgo
+type Callbacks struct {
+	Log        func(level int, msg string, keyValues ...interface{})
+	LogFilters []func(libLevel int, msg string) bool
+}
+
+// callbacks is initialized with default callbacks, but can be changed by SetLoggerCbs
+var callbacks = Callbacks{
+	Log: logFallback,
+	LogFilters: []func(libLevel int, msg string) bool{
+		LogFilterLevel,
+		LogFilterOutput,
+	},
+}
+
+// SetLoggerCbs receives Callbacks type to be used to log libbpf outputs and to filter out those outputs
+func SetLoggerCbs(cbs Callbacks) {
+	if cbs.Log == nil {
+		cbs.Log = logFallback
+	}
+
+	callbacks = cbs
+}
+
+// logFallback:
+// - level is ignored in this stage
+// - type coercion only takes care of string types
+// - keyValues is not required to contain pairs
+// - outputs all to stderr
+func logFallback(level int, msg string, keyValues ...interface{}) {
+	var (
+		args   = make([]string, 0)
+		outMsg = msg
+	)
+
+	for _, v := range keyValues {
+		if s, ok := v.(string); ok {
+			outMsg += " [%s]"
+			args = append(args, s)
+		}
+	}
+
+	outMsg += "\n"
+	if len(keyValues) > 0 {
+		fmt.Fprintf(os.Stderr, outMsg, args)
+	} else {
+		fmt.Fprint(os.Stderr, outMsg)
+	}
+}
+
+// LogFilterLevel filters by checking its print level
+// In case the consumer defines its own filters functions via SetLoggerCbs, this can also be passed
+func LogFilterLevel(libbpfPrintLevel int, output string) bool {
+	return libbpfPrintLevel != LibbpfWarnLevel
+}
+
+var (
+	// triggered by: libbpf/src/nlattr.c->libbpf_nla_dump_errormsg()
+	// "libbpf: Kernel error message: %s\n"
+	// 1. %s = "Exclusivity flag on"
+	regexKernelExclusivityFlagOn = regexp.MustCompile(`libbpf:.*Kernel error message:.*Exclusivity flag on`)
+
+	// triggered by: libbpf/src/libbpf.c->bpf_program__attach_kprobe_opts()
+	// "libbpf: prog '%s': failed to create %s '%s+0x%zx' perf event: %s\n"
+	// 1. %s = trace_check_map_func_compatibility
+	// 2. %s = kretprobe or kprobe
+	// 3. %s = check_map_func_compatibility (function name)
+	// 4. %x = offset (ignored in this check)
+	// 5. %s = No such file or directory
+	regexKprobePerfEvent = regexp.MustCompile(`libbpf:.*prog 'trace_check_map_func_compatibility'.*failed to create kprobe.*perf event: No such file or directory`)
+
+	// triggered by: libbpf/src/libbpf.c->bpf_program__attach_fd()
+	// "libbpf: prog '%s': failed to attach to %s: %s\n"
+	// 1. %s = cgroup_skb_ingress or cgroup_skb_egress
+	// 2. %s = cgroup
+	// 3. %s = Invalid argument
+	regexAttachCgroup = regexp.MustCompile(`libbpf:.*prog 'cgroup_skb_ingress|cgroup_skb_egress'.*failed to attach to cgroup.*Invalid argument`)
+)
+
+// LogFilterOutput filters out some errors by using regex
+// In case the consumer defines its own filters functions via SetLoggerCbs, this can also be passed
+func LogFilterOutput(libbpfPrintLevel int, output string) bool {
+	// BUG: https:/github.com/aquasecurity/tracee/issues/1676
+	if regexKernelExclusivityFlagOn.MatchString(output) {
+		return true
+	}
+
+	// BUG: https://github.com/aquasecurity/tracee/issues/2446
+	if regexKprobePerfEvent.MatchString(output) {
+		return true
+	}
+
+	// AttachCgroupLegacy() will first try AttachCgroup() and it might fail. This
+	// is not an error and is the best way of probing for eBPF cgroup attachment
+	// link existence.
+	if regexAttachCgroup.MatchString(output) {
+		return true
+	}
+
+	return false
+}

--- a/logger_cb_test.go
+++ b/logger_cb_test.go
@@ -1,0 +1,43 @@
+package libbpfgo
+
+import "testing"
+
+func TestLogFilterOutput(t *testing.T) {
+	tests := []struct {
+		libbpfPrintLevel int
+		output           string
+		expectedResult   bool
+	}{
+		{
+			output:         "libbpf: prog 'trace_check_map_func_compatibility': failed to create kprobe 'check_map_func_compatibility+0x0' perf event: No such file or directory\n",
+			expectedResult: true,
+		},
+		{
+			output:         "libbpf: Kernel error message: Exclusivity flag on\n",
+			expectedResult: true,
+		},
+		{
+			output:         "libbpf: prog 'cgroup_skb_ingress': failed to attach to cgroup 'cgroup': Invalid argument\n",
+			expectedResult: true,
+		},
+		{
+			output:         "libbpf: prog 'cgroup_skb_egress': failed to attach to cgroup 'cgroup': Invalid argument\n",
+			expectedResult: true,
+		},
+		{
+			output:         "This is not a log message that should be filtered\n",
+			expectedResult: false,
+		},
+		{
+			output:         "libbpf: This is not a log message that should be filtered\n",
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := LogFilterOutput(test.libbpfPrintLevel, test.output)
+		if result != test.expectedResult {
+			t.Errorf("For input '%s', expected %v but got %v", test.output, test.expectedResult, result)
+		}
+	}
+}

--- a/selftest/log-callbacks/Makefile
+++ b/selftest/log-callbacks/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/log-callbacks/go.mod
+++ b/selftest/log-callbacks/go.mod
@@ -1,0 +1,9 @@
+module github.com/aquasecurity/libbpfgo/selftest/log-callbacks
+
+go 1.18
+
+require github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0
+
+require golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/log-callbacks/go.sum
+++ b/selftest/log-callbacks/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/selftest/log-callbacks/main.bpf.c
+++ b/selftest/log-callbacks/main.bpf.c
@@ -1,0 +1,13 @@
+//+build ignore
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include "vmlinux.h"
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/log-callbacks/main.go
+++ b/selftest/log-callbacks/main.go
@@ -1,0 +1,44 @@
+package main
+
+import "C"
+
+import (
+	"os"
+	"strings"
+
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+var logOutput []string
+
+func log(level int, msg string, keyValues ...interface{}) {
+	logOutput = append(logOutput, msg)
+}
+
+func main() {
+	filterMatch := "found program 'kprobe__sys_mmap'"
+	bpf.SetLoggerCbs(bpf.Callbacks{
+		Log: log, // use log() as a handler for libbpf outputs that are not excluded by LogFilters
+		LogFilters: []func(libLevel int, msg string) bool{
+			func(libLevel int, msg string) bool {
+				// filter all output but containing "found program 'kprobe__sys_mmap'"
+				return !strings.Contains(msg, filterMatch)
+			},
+		},
+	})
+
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	if len(logOutput) != 1 {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("Log output should contain only one output matching the string: %s", filterMatch))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("Log output: %v", logOutput))
+		os.Exit(-1)
+	}
+}

--- a/selftest/log-callbacks/run.sh
+++ b/selftest/log-callbacks/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh


### PR DESCRIPTION
commit 761bb030fcb998dfe9915601a538f6087fb6d978

    selftest: add log-callbacks

commit 56803f4389f7557a47eba7e7e78015cddefcf424

    logger: introduce logger callbacks
    
    loggerCallback() calls callbacks, log() and []logFnFilters(),
    which can be set by the libbpfgo consumer via SetLoggerCbs().
    
    This moves output filtering from C libbpf_print_fn() to
    Go filterOutput() which can be set as one of the slice of filter funcs.
    
    This also introduces LogWarnLevel, LogInfoLevel and LogDebugLevel
    constants.

Fixes: #276
Fixes: #6 
Fixes: #55 
Fixex: https://github.com/aquasecurity/tracee/issues/2417

- https://github.com/aquasecurity/tracee/issues/2417
- #276
- #6
- #55

Related fix during the work:

- #285 

# Tests

```shell
libbpfgo/selftest/log-callbacks on  2417-logger-callback [$!?]
❯ make
make -C /home/gg/code/libbpfgo libbpfgo-static
make[1]: Entering directory '/home/gg/code/libbpfgo'
CC=clang \
        CGO_CFLAGS="-I/home/gg/code/libbpfgo/output" \
        CGO_LDFLAGS="-lelf -lz /home/gg/code/libbpfgo/output/libbpf.a" \
        GOOS=linux GOARCH=amd64 \
        go build \
        -tags netgo -ldflags '-w -extldflags "-static"' \
        .
...

libbpfgo/selftest/log-callbacks on  2417-logger-callback [$!?]
❯ sudo ./main-static                     

libbpfgo/selftest/log-callbacks on  2417-logger-callback [$!?]
❯ echo $?                                
0
```

Changing one filter callback for tests purpose only (== instead of !=):

```go
func(libLevel int, msg string) bool {
    return libLevel == C.LIBBPF_WARN
},
```

```shell
tracee on  main [$!?⇡] via 🐹 v1.19.5 via ⍱ v2.3.4 took 3s 
❯ sudo ./dist/tracee -t uid=1000 -t comm=who --log warn 2>&1 | head -20
{"level":"warn","ts":1675175312.2060382,"msg":"libbpf: loading object 'embedded-core' from buffer"}
{"level":"warn","ts":1675175312.2061195,"msg":"libbpf: elf: section(3) raw_tracepoint/sys_enter, size 248, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2061718,"msg":"libbpf: sec 'raw_tracepoint/sys_enter': found program 'tracepoint__raw_syscalls__sys_enter' at insn offset 0 (0 bytes), code size 31 insns (248 bytes)"}
{"level":"warn","ts":1675175312.2062,"msg":"libbpf: elf: section(4) .relraw_tracepoint/sys_enter, size 32, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.2062263,"msg":"libbpf: elf: section(5) raw_tracepoint/sys_enter_init, size 2368, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2062707,"msg":"libbpf: sec 'raw_tracepoint/sys_enter_init': found program 'sys_enter_init' at insn offset 0 (0 bytes), code size 296 insns (2368 bytes)"}
{"level":"warn","ts":1675175312.206299,"msg":"libbpf: elf: section(6) .relraw_tracepoint/sys_enter_init, size 160, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.206323,"msg":"libbpf: elf: section(7) raw_tracepoint/sys_enter_submit, size 24904, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2063725,"msg":"libbpf: sec 'raw_tracepoint/sys_enter_submit': found program 'sys_enter_submit' at insn offset 0 (0 bytes), code size 3113 insns (24904 bytes)"}
{"level":"warn","ts":1675175312.2064219,"msg":"libbpf: elf: section(8) .relraw_tracepoint/sys_enter_submit, size 416, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.2064548,"msg":"libbpf: elf: section(9) raw_tracepoint/sys_exit, size 312, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2065027,"msg":"libbpf: sec 'raw_tracepoint/sys_exit': found program 'tracepoint__raw_syscalls__sys_exit' at insn offset 0 (0 bytes), code size 39 insns (312 bytes)"}
{"level":"warn","ts":1675175312.2065287,"msg":"libbpf: elf: section(10) .relraw_tracepoint/sys_exit, size 32, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.2065518,"msg":"libbpf: elf: section(11) raw_tracepoint/sys_exit_init, size 1200, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2065969,"msg":"libbpf: sec 'raw_tracepoint/sys_exit_init': found program 'sys_exit_init' at insn offset 0 (0 bytes), code size 150 insns (1200 bytes)"}
{"level":"warn","ts":1675175312.2066414,"msg":"libbpf: elf: section(12) .relraw_tracepoint/sys_exit_init, size 144, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.2066822,"msg":"libbpf: elf: section(13) raw_tracepoint/sys_exit_submit, size 18976, link 0, flags 6, type=1"}
{"level":"warn","ts":1675175312.2067318,"msg":"libbpf: sec 'raw_tracepoint/sys_exit_submit': found program 'sys_exit_submit' at insn offset 0 (0 bytes), code size 2372 insns (18976 bytes)"}
{"level":"warn","ts":1675175312.2067814,"msg":"libbpf: elf: section(14) .relraw_tracepoint/sys_exit_submit, size 416, link 223, flags 40, type=9"}
{"level":"warn","ts":1675175312.206826,"msg":"libbpf: elf: section(15) raw_tracepoint/trace_sys_enter, size 8120, link 0, flags 6, type=1"}
```

### Context

- https://github.com/aquasecurity/tracee/pull/2600