### PR TITLE
fix: va_end() va_list copy rather than copied

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -28,7 +28,7 @@ int libbpf_print_fn(enum libbpf_print_level level, // libbpf print level
 
   va_copy(check, args);
   ret = vsnprintf(str, sizeof(str), format, check);
-  va_end(args);
+  va_end(check);
 
   if (ret <= 0) {
     goto done;


### PR DESCRIPTION
> Each invocation of va_copy() must be matched by a corresponding invocation of va_end() in the same function.

https://man7.org/linux/man-pages/man3/va_arg.3.html

Fix:
- #285 