### PR TITLE
ci: Use Go 1.20

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.18"
+        go-version: "1.20"
     - name: Install Compilers & Formatters
       run: |
         sudo apt-get update


### PR DESCRIPTION
Golang 1.20 was released early this month https://go.dev/blog/go1.20, bringing some nice perf improvements:

> Improved performance
> Compiler and garbage collector improvements have reduced memory overhead and improved overall CPU performance by up to 2%.
> Work specifically targeting compilation times led to build improvements by up to 10%. This brings build speeds back in line with Go 1.17.