### PR TITLE
chore: call bpf_program__attach_iter from go

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -125,24 +125,43 @@ int bpf_prog_detach_cgroup_legacy(
   return syscall(__NR_bpf, BPF_PROG_DETACH, &attr, sizeof(attr));
 }
 
-struct bpf_link *bpf_prog_attach_iter(struct bpf_program *prog, __u32 map_fd,
-                                      enum bpf_cgroup_iter_order order,
-                                      __u32 cgroup_fd, __u64 cgroup_id,
-                                      __u32 tid, __u32 pid, __u32 pid_fd) {
-  DECLARE_LIBBPF_OPTS(bpf_iter_attach_opts, opts);
-  union bpf_iter_link_info linfo;
-  memset(&linfo, 0, sizeof(linfo));
-  linfo.map.map_fd = map_fd;
-  linfo.cgroup.order = order;
-  linfo.cgroup.cgroup_fd = cgroup_fd;
-  linfo.cgroup.cgroup_id = cgroup_id;
-  linfo.task.tid = tid;
-  linfo.task.pid = pid;
-  linfo.task.pid_fd = pid_fd;
-  opts.link_info = &linfo;
-  opts.link_info_len = sizeof(linfo);
+struct bpf_iter_attach_opts *
+bpf_iter_attach_opts_new(__u32 map_fd, enum bpf_cgroup_iter_order order,
+                         __u32 cgroup_fd, __u64 cgroup_id, __u32 tid, __u32 pid,
+                         __u32 pid_fd) {
+  union bpf_iter_link_info *linfo;
+  linfo = calloc(1, sizeof(*linfo));
+  if (!linfo)
+    return NULL;
 
-  return bpf_program__attach_iter(prog, &opts);
+  linfo->map.map_fd = map_fd;
+  linfo->cgroup.order = order;
+  linfo->cgroup.cgroup_fd = cgroup_fd;
+  linfo->cgroup.cgroup_id = cgroup_id;
+  linfo->task.tid = tid;
+  linfo->task.pid = pid;
+  linfo->task.pid_fd = pid_fd;
+
+  struct bpf_iter_attach_opts *opts;
+  opts = calloc(1, sizeof(*opts));
+  if (!opts) {
+    free(linfo);
+    return NULL;
+  }
+
+  opts->sz = sizeof(*opts);
+  opts->link_info_len = sizeof(*linfo);
+  opts->link_info = linfo;
+
+  return opts;
+}
+
+void bpf_iter_attach_opts_free(struct bpf_iter_attach_opts *opts) {
+  if (!opts)
+    return;
+
+  free(opts->link_info);
+  free(opts);
 }
 
 struct bpf_object *open_bpf_object(char *btf_file_path, char *kconfig_path,


### PR DESCRIPTION
This changes libbpfgo to call `bpf_program__attach_iter` directly from go instead of doing this via a C wrapper. What this means is that we maintained opts creation in C, but the actual libbpf attach call is done in go.

This creates two new functions in libbpfgo.h as helpers:
- `bpf_iter_attach_opts_new()`
- `bpf_iter_attach_opts_free()`