### PR TITLE
clang-format: add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,124 @@
+---
+Language: Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentExternBlock: AfterExternBlock
+IndentRequires: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false 
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard: Latest
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+...
+

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -2,7 +2,7 @@
 #define __LIBBPF_GO_H__
 
 #ifdef __powerpc64__
-#define __SANE_USERSPACE_TYPES__ 1
+    #define __SANE_USERSPACE_TYPES__ 1
 #endif
 
 #include <errno.h>
@@ -20,168 +20,180 @@ extern void loggerCallback(enum libbpf_print_level level, char *output);
 
 int libbpf_print_fn(enum libbpf_print_level level, // libbpf print level
                     const char *format,            // format used for the msg
-                    va_list args) {                // args used by format
+                    va_list args)
+{ // args used by format
 
-  int ret;
-  size_t len;
-  char *out;
-  va_list check;
+    int ret;
+    size_t len;
+    char *out;
+    va_list check;
 
-  va_copy(check, args);
-  ret = vsnprintf(NULL, 0, format, check); // get output length
-  va_end(check);
+    va_copy(check, args);
+    ret = vsnprintf(NULL, 0, format, check); // get output length
+    va_end(check);
 
-  if (ret < 0)
+    if (ret < 0)
+        return ret;
+
+    len = ret + 1; // add 1 for NUL
+    out = malloc(len);
+    if (!out)
+        return -ENOMEM;
+
+    va_copy(check, args);
+    ret = vsnprintf(out, len, format, check);
+    va_end(check);
+
+    if (ret > 0)
+        loggerCallback(level, out);
+
+    free(out);
+
     return ret;
-
-  len = ret + 1; // add 1 for NUL
-  out = malloc(len);
-  if (!out)
-    return -ENOMEM;
-
-  va_copy(check, args);
-  ret = vsnprintf(out, len, format, check);
-  va_end(check);
-
-  if (ret > 0)
-    loggerCallback(level, out);
-
-  free(out);
-
-  return ret;
 }
 
-void set_print_fn() { libbpf_set_print(libbpf_print_fn); }
+void set_print_fn()
+{
+    libbpf_set_print(libbpf_print_fn);
+}
 
 extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);
 extern void perfLostCallback(void *ctx, int cpu, __u64 cnt);
 extern int ringbufferCallback(void *ctx, void *data, size_t size);
 
-struct ring_buffer *init_ring_buf(int map_fd, uintptr_t ctx) {
-  struct ring_buffer *rb = NULL;
-
-  rb = ring_buffer__new(map_fd, ringbufferCallback, (void *)ctx, NULL);
-  if (!rb) {
-    int saved_errno = errno;
-    fprintf(stderr, "Failed to initialize ring buffer: %s\n", strerror(errno));
-    errno = saved_errno;
-    return NULL;
-  }
-
-  return rb;
-}
-
-struct perf_buffer *init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx) {
-  struct perf_buffer_opts pb_opts = {};
-  struct perf_buffer *pb = NULL;
-
-  pb_opts.sz = sizeof(struct perf_buffer_opts);
-
-  pb = perf_buffer__new(map_fd, page_cnt, perfCallback, perfLostCallback,
-                        (void *)ctx, &pb_opts);
-  if (!pb) {
-    int saved_errno = errno;
-    fprintf(stderr, "Failed to initialize perf buffer: %s\n", strerror(errno));
-    errno = saved_errno;
-    return NULL;
-  }
-
-  return pb;
-}
-
-void get_internal_map_init_value(struct bpf_map *map, void *value) {
-  size_t psize;
-  const void *data;
-  data = bpf_map__initial_value(map, &psize);
-  memcpy(value, data, psize);
-}
-
-int bpf_prog_attach_cgroup_legacy(
-    int prog_fd,   // eBPF program file descriptor
-    int target_fd, // cgroup directory file descriptor
-    int type)      // BPF_CGROUP_INET_{INGRESS,EGRESS}, ...
+struct ring_buffer *init_ring_buf(int map_fd, uintptr_t ctx)
 {
-  union bpf_attr attr;
-  memset(&attr, 0, sizeof(attr));
-  attr.target_fd = target_fd;
-  attr.attach_bpf_fd = prog_fd;
-  attr.attach_type = type;
-  attr.attach_flags = BPF_F_ALLOW_MULTI; // or BPF_F_ALLOW_OVERRIDE
+    struct ring_buffer *rb = NULL;
 
-  return syscall(__NR_bpf, BPF_PROG_ATTACH, &attr, sizeof(attr));
+    rb = ring_buffer__new(map_fd, ringbufferCallback, (void *) ctx, NULL);
+    if (!rb) {
+        int saved_errno = errno;
+        fprintf(stderr, "Failed to initialize ring buffer: %s\n", strerror(errno));
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return rb;
 }
 
-int bpf_prog_detach_cgroup_legacy(
-    int prog_fd,   // eBPF program file descriptor
-    int target_fd, // cgroup directory file descriptor
-    int type)      // BPF_CGROUP_INET_{INGRESS,EGRESS}, ...
+struct perf_buffer *init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx)
 {
-  union bpf_attr attr;
-  memset(&attr, 0, sizeof(attr));
-  attr.target_fd = target_fd;
-  attr.attach_bpf_fd = prog_fd;
-  attr.attach_type = type;
+    struct perf_buffer_opts pb_opts = {};
+    struct perf_buffer *pb = NULL;
 
-  return syscall(__NR_bpf, BPF_PROG_DETACH, &attr, sizeof(attr));
+    pb_opts.sz = sizeof(struct perf_buffer_opts);
+
+    pb = perf_buffer__new(map_fd, page_cnt, perfCallback, perfLostCallback, (void *) ctx, &pb_opts);
+    if (!pb) {
+        int saved_errno = errno;
+        fprintf(stderr, "Failed to initialize perf buffer: %s\n", strerror(errno));
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return pb;
 }
 
-struct bpf_iter_attach_opts *
-bpf_iter_attach_opts_new(__u32 map_fd, enum bpf_cgroup_iter_order order,
-                         __u32 cgroup_fd, __u64 cgroup_id, __u32 tid, __u32 pid,
-                         __u32 pid_fd) {
-  union bpf_iter_link_info *linfo;
-  linfo = calloc(1, sizeof(*linfo));
-  if (!linfo)
-    return NULL;
-
-  linfo->map.map_fd = map_fd;
-  linfo->cgroup.order = order;
-  linfo->cgroup.cgroup_fd = cgroup_fd;
-  linfo->cgroup.cgroup_id = cgroup_id;
-  linfo->task.tid = tid;
-  linfo->task.pid = pid;
-  linfo->task.pid_fd = pid_fd;
-
-  struct bpf_iter_attach_opts *opts;
-  opts = calloc(1, sizeof(*opts));
-  if (!opts) {
-    free(linfo);
-    return NULL;
-  }
-
-  opts->sz = sizeof(*opts);
-  opts->link_info_len = sizeof(*linfo);
-  opts->link_info = linfo;
-
-  return opts;
+void get_internal_map_init_value(struct bpf_map *map, void *value)
+{
+    size_t psize;
+    const void *data;
+    data = bpf_map__initial_value(map, &psize);
+    memcpy(value, data, psize);
 }
 
-void bpf_iter_attach_opts_free(struct bpf_iter_attach_opts *opts) {
-  if (!opts)
-    return;
+int bpf_prog_attach_cgroup_legacy(int prog_fd,   // eBPF program file descriptor
+                                  int target_fd, // cgroup directory file descriptor
+                                  int type)      // BPF_CGROUP_INET_{INGRESS,EGRESS}, ...
+{
+    union bpf_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.target_fd = target_fd;
+    attr.attach_bpf_fd = prog_fd;
+    attr.attach_type = type;
+    attr.attach_flags = BPF_F_ALLOW_MULTI; // or BPF_F_ALLOW_OVERRIDE
 
-  free(opts->link_info);
-  free(opts);
+    return syscall(__NR_bpf, BPF_PROG_ATTACH, &attr, sizeof(attr));
 }
 
-struct bpf_object *open_bpf_object(char *btf_file_path, char *kconfig_path,
-                                   char *bpf_obj_name, const void *obj_buf,
-                                   size_t obj_buf_size) {
-  struct bpf_object_open_opts opts = {};
-  opts.btf_custom_path = btf_file_path;
-  opts.kconfig = kconfig_path;
-  opts.object_name = bpf_obj_name;
-  opts.sz = sizeof(opts);
+int bpf_prog_detach_cgroup_legacy(int prog_fd,   // eBPF program file descriptor
+                                  int target_fd, // cgroup directory file descriptor
+                                  int type)      // BPF_CGROUP_INET_{INGRESS,EGRESS}, ...
+{
+    union bpf_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.target_fd = target_fd;
+    attr.attach_bpf_fd = prog_fd;
+    attr.attach_type = type;
 
-  struct bpf_object *obj = bpf_object__open_mem(obj_buf, obj_buf_size, &opts);
-  if (obj == NULL) {
-    int saved_errno = errno;
-    fprintf(stderr, "Failed to open bpf object: %s\n", strerror(errno));
-    errno = saved_errno;
-    return NULL;
-  }
+    return syscall(__NR_bpf, BPF_PROG_DETACH, &attr, sizeof(attr));
+}
 
-  return obj;
+struct bpf_iter_attach_opts *bpf_iter_attach_opts_new(__u32 map_fd,
+                                                      enum bpf_cgroup_iter_order order,
+                                                      __u32 cgroup_fd,
+                                                      __u64 cgroup_id,
+                                                      __u32 tid,
+                                                      __u32 pid,
+                                                      __u32 pid_fd)
+{
+    union bpf_iter_link_info *linfo;
+    linfo = calloc(1, sizeof(*linfo));
+    if (!linfo)
+        return NULL;
+
+    linfo->map.map_fd = map_fd;
+    linfo->cgroup.order = order;
+    linfo->cgroup.cgroup_fd = cgroup_fd;
+    linfo->cgroup.cgroup_id = cgroup_id;
+    linfo->task.tid = tid;
+    linfo->task.pid = pid;
+    linfo->task.pid_fd = pid_fd;
+
+    struct bpf_iter_attach_opts *opts;
+    opts = calloc(1, sizeof(*opts));
+    if (!opts) {
+        free(linfo);
+        return NULL;
+    }
+
+    opts->sz = sizeof(*opts);
+    opts->link_info_len = sizeof(*linfo);
+    opts->link_info = linfo;
+
+    return opts;
+}
+
+void bpf_iter_attach_opts_free(struct bpf_iter_attach_opts *opts)
+{
+    if (!opts)
+        return;
+
+    free(opts->link_info);
+    free(opts);
+}
+
+struct bpf_object *open_bpf_object(char *btf_file_path,
+                                   char *kconfig_path,
+                                   char *bpf_obj_name,
+                                   const void *obj_buf,
+                                   size_t obj_buf_size)
+{
+    struct bpf_object_open_opts opts = {};
+    opts.btf_custom_path = btf_file_path;
+    opts.kconfig = kconfig_path;
+    opts.object_name = bpf_obj_name;
+    opts.sz = sizeof(opts);
+
+    struct bpf_object *obj = bpf_object__open_mem(obj_buf, obj_buf_size, &opts);
+    if (obj == NULL) {
+        int saved_errno = errno;
+        fprintf(stderr, "Failed to open bpf object: %s\n", strerror(errno));
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return obj;
 }
 
 #endif


### PR DESCRIPTION
Add a .clang-format file to the root of the repository. This file is used by clang-format to format the code. The file is based on the Tracee style, with some modifications to make it more suitable for libbpfgo.

This commit also formats the code using the new .clang-format file.