### PR TITLE
Add explicit timeout to perf + ring buffer polling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,7 +99,7 @@ mymap.Update(key, value)
 
 // ring buffer
 rb, _ := bpfModule.InitRingBuffer("events", eventsChannel, buffSize)
-rb.Start()
+rb.Poll(300)
 e := <-eventsChannel
 ```
 

--- a/selftest/cgroup-legacy/main.go
+++ b/selftest/cgroup-legacy/main.go
@@ -63,7 +63,7 @@ func main() {
 	defer stop()
 
 	// start eBPF perf buffer event polling
-	bpfPerfBuffer.Start()
+	bpfPerfBuffer.Poll(300)
 
 	go func() {
 		_, err := exec.Command("ping", "127.0.0.1", "-c 5", "-w 10").Output()

--- a/selftest/cgroup/main.go
+++ b/selftest/cgroup/main.go
@@ -52,7 +52,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		for i := 0; i < 10; i++ {

--- a/selftest/global-variable/main.go
+++ b/selftest/global-variable/main.go
@@ -70,7 +70,7 @@ func main() {
 		exitWithErr(err)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	go func() {
 		time.Sleep(time.Second)
 		syscall.Mmap(999, 999, 999, 1, 1)

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -95,7 +95,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	pb.Start()
+	pb.Poll(300)
 
 	go func() {
 		time.Sleep(time.Second)

--- a/selftest/multiple-objects/main.go
+++ b/selftest/multiple-objects/main.go
@@ -82,7 +82,7 @@ func main() {
 		fmt.Println("couldn't init ringbuffer")
 		os.Exit(-1)
 	}
-	ringBuf.Start()
+	ringBuf.Poll(300)
 	gotOne, gotTwo := false, false
 
 thisloop:

--- a/selftest/netns/main.go
+++ b/selftest/netns/main.go
@@ -47,7 +47,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		l, err := net.Listen("tcp", "127.0.0.1:")

--- a/selftest/perfbuffers/main.go
+++ b/selftest/perfbuffers/main.go
@@ -64,7 +64,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	pb.Start()
+	pb.Poll(300)
 
 	numberOfEventsReceived := 0
 

--- a/selftest/ringbuffers/main.go
+++ b/selftest/ringbuffers/main.go
@@ -64,7 +64,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 
 	numberOfEventsReceived := 0
 	go func() {

--- a/selftest/set-attach/main.go
+++ b/selftest/set-attach/main.go
@@ -53,7 +53,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		for {

--- a/selftest/spinlocks/main.go
+++ b/selftest/spinlocks/main.go
@@ -85,7 +85,7 @@ func main() {
 	var zero uint32
 	lostEventCounterMap.Update(unsafe.Pointer(&lostEventCounterKey), unsafe.Pointer(&zero))
 
-	rb.Start()
+	rb.Poll(300)
 
 	numberOfEventsReceived := 0
 	go func() {

--- a/selftest/tc/main.go
+++ b/selftest/tc/main.go
@@ -64,7 +64,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		_, err := exec.Command("ping", "localhost", "-c 10").Output()

--- a/selftest/tracing/main.go
+++ b/selftest/tracing/main.go
@@ -67,7 +67,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		for {

--- a/selftest/uprobe/main.go
+++ b/selftest/uprobe/main.go
@@ -81,7 +81,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 
 	numberOfEventsReceived := 0
 

--- a/selftest/xdp/main.go
+++ b/selftest/xdp/main.go
@@ -49,7 +49,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	rb.Start()
+	rb.Poll(300)
 	numberOfEventsReceived := 0
 	go func() {
 		_, err := exec.Command("ping", "localhost", "-c 10").Output()


### PR DESCRIPTION
Right now it's hardcoded to 300ms which might not work for every use-case. Having it as a parameter allows users to decide their tradeoff between latency and overhead.

cc @kakkoyun 