### PR TITLE
logger: fix callback log level and output

### DIFF
--- a/logger_cb.go
+++ b/logger_cb.go
@@ -8,7 +8,6 @@ import "C"
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 // This callback definition needs to be in a different file from where it is declared in C
@@ -19,7 +18,6 @@ import (
 //export loggerCallback
 func loggerCallback(libbpfPrintLevel int, libbpfOutput *C.char) {
 	goOutput := C.GoString(libbpfOutput)
-	goOutput = strings.TrimSuffix(goOutput, "\n")
 
 	for _, fnFilterOut := range callbacks.LogFilters {
 		if fnFilterOut != nil {
@@ -29,6 +27,7 @@ func loggerCallback(libbpfPrintLevel int, libbpfOutput *C.char) {
 		}
 	}
 
+	// pass received output to callback, leaving formatting to consumer
 	callbacks.Log(libbpfPrintLevel, goOutput)
 }
 
@@ -62,9 +61,6 @@ func SetLoggerCbs(cbs Callbacks) {
 
 // logFallback is the default logger callback
 // - level is ignored
-// - output, suffixed with a newline, is printed to stderr
 func logFallback(level int, msg string) {
-	var outMsg = msg + "\n"
-
-	fmt.Fprint(os.Stderr, outMsg)
+	fmt.Fprint(os.Stderr, msg)
 }

--- a/logger_cb.go
+++ b/logger_cb.go
@@ -18,12 +18,7 @@ import (
 //
 //export loggerCallback
 func loggerCallback(libbpfPrintLevel int, libbpfOutput *C.char) {
-	var (
-		level    int
-		goOutput string
-	)
-
-	goOutput = C.GoString(libbpfOutput)
+	goOutput := C.GoString(libbpfOutput)
 	goOutput = strings.TrimSuffix(goOutput, "\n")
 
 	for _, fnFilterOut := range callbacks.LogFilters {
@@ -34,7 +29,7 @@ func loggerCallback(libbpfPrintLevel int, libbpfOutput *C.char) {
 		}
 	}
 
-	callbacks.Log(level, goOutput)
+	callbacks.Log(libbpfPrintLevel, goOutput)
 }
 
 const (

--- a/logger_cb_test.go
+++ b/logger_cb_test.go
@@ -46,7 +46,6 @@ func TestLogFallback(t *testing.T) {
 		_, err = io.Copy(&buf, r)
 		require.NoError(t, err, "failed to copy from read end to buffer")
 
-		// The message should be printed to stderr with a newline
-		assert.Equal(t, tc.message+"\n", buf.String())
+		assert.Equal(t, tc.message, buf.String())
 	}
 }


### PR DESCRIPTION
commit e99ef7235774fcbdfa3d3f769a18f9fbbbf3bf69

    logger: pass raw libbpf print output
    
    Due to libbpf output being escaped, we should pass the raw output to the
    consumer, letting them decide how to format it, since them might want
    to, for example, use it in a logger or print directly to stderr.
    
    Reported-by: @yanivagman

commit 9f21a9d91dc47c3152c95c7899fe7493e0d23452

    logger: fix callback log level

Fixes: #311
Fixes: #313