### PR TITLE
makefile: turn clang the default compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OUTPUT = ./output
 SELFTEST = ./selftest
 HELPERS = ./helpers
 
-CC = clang
 CLANG = clang
+CC = $(CLANG)
 GO = go
 VAGRANT = vagrant
 CLANG_FMT = clang-format

--- a/selftest/common/Makefile
+++ b/selftest/common/Makefile
@@ -5,8 +5,8 @@ OUTPUT = ../../output
 LIBBPF_SRC = $(abspath ../../libbpf/src)
 LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
 
-CC = gcc
 CLANG = clang
+CC = $(CLANG)
 GO = go
 
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')


### PR DESCRIPTION
- libbpfgo supports clang only.