### PR TITLE
vagrant: fix lack of asm/types.h on Ubuntu images

### DIFF
--- a/builder/prepare-ubuntu.sh
+++ b/builder/prepare-ubuntu.sh
@@ -82,6 +82,7 @@ install_pkgs \
     llvm-"${CLANG_VERSION}" clang-"${CLANG_VERSION}" clang-format-"${CLANG_VERSION}" \
     linux-headers-generic \
     linux-tools-generic linux-tools-"$(uname -r)" \
+    gcc-multilib \
     zlib1g-dev libelf-dev libbpf-dev
 
 setup_go


### PR DESCRIPTION
This adds missing includes as running the test in a vagrant vm was having errors like:

```
vagrant@libbpfgo-amd64-vm:/vagrant$ make test
UAPIDIR=/vagrant/output \
	make -C /vagrant/libbpf/src install_uapi_headers
make[1]: Entering directory '/vagrant/libbpf/src'
  INSTALL  ../include/uapi/linux/bpf.h ../include/uapi/linux/bpf_common.h ../include/uapi/linux/btf.h
make[1]: Leaving directory '/vagrant/libbpf/src'
CC=clang \
	CGO_CFLAGS="-I/vagrant/output" \
	CGO_LDFLAGS="-lelf -lz /vagrant/output/libbpf.a" \
	GOOS=linux GOARCH=amd64 \
	go build \
	-tags netgo -ldflags '-w -extldflags "-static"' \
	.
make -C ./selftest/build
make[1]: Entering directory '/vagrant/selftest/build'
clang -g -O2 -Wall -fpie -target bpf -D__TARGET_ARCH_amd64 -I../../output -I/vagrant/selftest/common -c libbpfgo_test.bpf.c -o libbpfgo_test.bpf.o
In file included from libbpfgo_test.bpf.c:2:
In file included from ../../output/linux/bpf.h:11:
/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found
#include <asm/types.h>
         ^~~~~~~~~~~~~
1 error generated.
make[1]: *** [Makefile:24: libbpfgo_test.bpf.o] Error 1
make[1]: Leaving directory '/vagrant/selftest/build'
make: *** [Makefile:59: libbpfgo-test-bpf-static] Error 2
```