### PR TITLE
libbpf bump

### DIFF
--- a/selftest/set-attach/main.bpf.c
+++ b/selftest/set-attach/main.bpf.c
@@ -11,7 +11,7 @@ struct {
 } events SEC(".maps");
 long ringbuffer_flags = 0;
 
-SEC("fentry/FUNC")
+SEC("fentry")
 int BPF_PROG(foobar)
 {
     int *process;

--- a/selftest/set-attach/main.go
+++ b/selftest/set-attach/main.go
@@ -27,13 +27,17 @@ func main() {
 		os.Exit(-1)
 	}
 
-	prog.SetProgramType(bpf.BPFProgTypeTracing)
+	// eBPF program type should only be set if it differs from the desired one
+	// commit d6e6286a12e7 ("libbpf: disassociate section handler on explicit bpf_program__set_type() call")
+	// prog.SetProgramType(bpf.BPFProgTypeTracing)
 	prog.SetAttachType(bpf.BPFAttachTypeTraceFentry)
+
 	err = prog.SetAttachTarget(0, "__x64_sys_mmap")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
+
 	err = bpfModule.BPFLoadObject()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
commit 8b6fa9e (HEAD -> libbpf-bump, rafaeldtinoco/libbpf-bump)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 2 17:51:30 2023

    selftest: fix set-attach test
    
    After libbpf commit 3fd6eebb2d4 ("libbpf: disassociate section handler
    on explicit bpf_program__set_type() call"):
    
     If user explicitly overrides programs's type with
     bpf_program__set_type() API call, we need to disassociate whatever
     SEC_DEF handler libbpf determined initially based on program's SEC()
     definition, as it's not goind to be valid anymore and could lead to
     crashes and/or confusing failures.
    
    The eBPF fentry program macro should only have the "fentry" keyword.

commit eba93d9
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 2 17:23:15 2023

    selftest: fix cgroup-legacy selftest

commit c291411 (tests)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 2 16:31:19 2023

    libbpf: bump to v1.2.0