### PR TITLE
chore: call bpf_object__open_mem from go

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -381,9 +381,13 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	}
 
 	cBTFFilePath := C.CString(args.BTFObjPath)
+	defer C.free(unsafe.Pointer(cBTFFilePath))
 	cKconfigPath := C.CString(args.KConfigFilePath)
+	defer C.free(unsafe.Pointer(cKconfigPath))
 	cBPFObjName := C.CString(args.BPFObjName)
+	defer C.free(unsafe.Pointer(cBPFObjName))
 	cBPFBuff := unsafe.Pointer(C.CBytes(args.BPFObjBuff))
+	defer C.free(cBPFBuff)
 	cBPFBuffSize := C.size_t(len(args.BPFObjBuff))
 
 	if len(args.KConfigFilePath) <= 2 {
@@ -391,14 +395,16 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 		cKconfigPath = nil
 	}
 
-	obj, errno := C.open_bpf_object(cBTFFilePath, cKconfigPath, cBPFObjName, cBPFBuff, cBPFBuffSize)
+	cOpts, errno := C.bpf_object_open_opts_new(cBTFFilePath, cKconfigPath, cBPFObjName)
+	if cOpts == nil {
+		return nil, fmt.Errorf("failed to create bpf_object_open_opts to %s: %w", args.BPFObjName, errno)
+	}
+	defer C.bpf_object_open_opts_free(cOpts)
+
+	obj, errno := C.bpf_object__open_mem(cBPFBuff, cBPFBuffSize, cOpts)
 	if obj == nil {
 		return nil, fmt.Errorf("failed to open BPF object %s: %w", args.BPFObjName, errno)
 	}
-
-	C.free(cBPFBuff)
-	C.free(unsafe.Pointer(cBPFObjName))
-	C.free(unsafe.Pointer(cBTFFilePath))
 
 	return &Module{
 		obj: obj,

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -175,27 +175,25 @@ void bpf_iter_attach_opts_free(struct bpf_iter_attach_opts *opts)
     free(opts);
 }
 
-struct bpf_object *open_bpf_object(char *btf_file_path,
-                                   char *kconfig_path,
-                                   char *bpf_obj_name,
-                                   const void *obj_buf,
-                                   size_t obj_buf_size)
+struct bpf_object_open_opts *
+bpf_object_open_opts_new(char *btf_file_path, char *kconfig_path, char *bpf_obj_name)
 {
-    struct bpf_object_open_opts opts = {};
-    opts.btf_custom_path = btf_file_path;
-    opts.kconfig = kconfig_path;
-    opts.object_name = bpf_obj_name;
-    opts.sz = sizeof(opts);
-
-    struct bpf_object *obj = bpf_object__open_mem(obj_buf, obj_buf_size, &opts);
-    if (obj == NULL) {
-        int saved_errno = errno;
-        fprintf(stderr, "Failed to open bpf object: %s\n", strerror(errno));
-        errno = saved_errno;
+    struct bpf_object_open_opts *opts;
+    opts = calloc(1, sizeof(*opts));
+    if (!opts)
         return NULL;
-    }
 
-    return obj;
+    opts->sz = sizeof(*opts);
+    opts->btf_custom_path = btf_file_path;
+    opts->kconfig = kconfig_path;
+    opts->object_name = bpf_obj_name;
+
+    return opts;
+}
+
+void bpf_object_open_opts_free(struct bpf_object_open_opts *opts)
+{
+    free(opts);
 }
 
 #endif


### PR DESCRIPTION
This changes libbpfgo to call bpf_object__open_mem directly from go instead of doing this via a C wrapper. What this means is that we maintained opts creation in C, but the actual libbpf object open call is done in go.

This creates two new functions in libbpfgo.h as helpers:
- bpf_object_open_opts_new()
- bpf_object_open_opts_free()

Context: #304

Additionally, this commit enforces the use of defer and resolves a potential CKconfigPath leak when len(args.KConfigFilePath) is > 2.