### PR TITLE
Allow building on Linux < 6.1

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -17,6 +17,7 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 #include <linux/bpf.h> // uapi
+#include <linux/version.h>
 
 extern void loggerCallback(enum libbpf_print_level level, char *output);
 
@@ -145,12 +146,15 @@ struct bpf_iter_attach_opts *bpf_iter_attach_opts_new(__u32 map_fd,
         return NULL;
 
     linfo->map.map_fd = map_fd;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
     linfo->cgroup.order = order;
     linfo->cgroup.cgroup_fd = cgroup_fd;
     linfo->cgroup.cgroup_id = cgroup_id;
     linfo->task.tid = tid;
     linfo->task.pid = pid;
     linfo->task.pid_fd = pid_fd;
+#endif
 
     struct bpf_iter_attach_opts *opts;
     opts = calloc(1, sizeof(*opts));


### PR DESCRIPTION
The latest release breaks build on lower kernel versions:

```
./libbpfgo.h:135:82: error: parameter 2 ('order') has incomplete type
  135 |                                                       enum bpf_cgroup_iter_order order,
      |                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
./libbpfgo.h: In function 'bpf_iter_attach_opts_new':
./libbpfgo.h:148:10: error: 'union bpf_iter_link_info' has no member named 'cgroup'
  148 |     linfo->cgroup.order = order;
      |          ^~
./libbpfgo.h:149:10: error: 'union bpf_iter_link_info' has no member named 'cgroup'
  149 |     linfo->cgroup.cgroup_fd = cgroup_fd;
      |          ^~
./libbpfgo.h:150:10: error: 'union bpf_iter_link_info' has no member named 'cgroup'
  150 |     linfo->cgroup.cgroup_id = cgroup_id;
      |          ^~
./libbpfgo.h:151:10: error: 'union bpf_iter_link_info' has no member named 'task'
  151 |     linfo->task.tid = tid;
      |          ^~
./libbpfgo.h:152:10: error: 'union bpf_iter_link_info' has no member named 'task'
  152 |     linfo->task.pid = pid;
      |          ^~
./libbpfgo.h:153:10: error: 'union bpf_iter_link_info' has no member named 'task'
  153 |     linfo->task.pid_fd = pid_fd;
      |          ^~) (typecheck)
```

We now pre-check the kernel version to allow builds on older systems as well.

Refers to https://github.com/kubernetes-sigs/security-profiles-operator/pull/1663