### PR TITLE
Fix double-free in `NewModuleFromBufferArgs`

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -383,6 +383,7 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	cBTFFilePath := C.CString(args.BTFObjPath)
 	defer C.free(unsafe.Pointer(cBTFFilePath))
 	cKconfigPath := C.CString(args.KConfigFilePath)
+	defer C.free(unsafe.Pointer(cKconfigPath))
 	cBPFObjName := C.CString(args.BPFObjName)
 	defer C.free(unsafe.Pointer(cBPFObjName))
 	cBPFBuff := unsafe.Pointer(C.CBytes(args.BPFObjBuff))
@@ -392,8 +393,6 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	if len(args.KConfigFilePath) <= 2 {
 		cKconfigPath = nil
 	}
-
-	defer C.free(unsafe.Pointer(cKconfigPath))
 
 	cOpts, errno := C.bpf_object_open_opts_new(cBTFFilePath, cKconfigPath, cBPFObjName)
 	if cOpts == nil {

--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -383,7 +383,6 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	cBTFFilePath := C.CString(args.BTFObjPath)
 	defer C.free(unsafe.Pointer(cBTFFilePath))
 	cKconfigPath := C.CString(args.KConfigFilePath)
-	defer C.free(unsafe.Pointer(cKconfigPath))
 	cBPFObjName := C.CString(args.BPFObjName)
 	defer C.free(unsafe.Pointer(cBPFObjName))
 	cBPFBuff := unsafe.Pointer(C.CBytes(args.BPFObjBuff))
@@ -391,9 +390,10 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	cBPFBuffSize := C.size_t(len(args.BPFObjBuff))
 
 	if len(args.KConfigFilePath) <= 2 {
-		C.free(unsafe.Pointer(cKconfigPath))
 		cKconfigPath = nil
 	}
+
+	defer C.free(unsafe.Pointer(cKconfigPath))
 
 	cOpts, errno := C.bpf_object_open_opts_new(cBTFFilePath, cKconfigPath, cBPFObjName)
 	if cOpts == nil {


### PR DESCRIPTION
In
https://github.com/aquasecurity/libbpfgo/commit/0238ec325a967ca48d8958f449e236b5bc432263 the freeing of C strings was changed to use defers. This can cause a double-free, which in the best case it will produce a crash. The reason why this happens is that the memory address at `defer` time is captured for later execution. If `KConfigFilePath` is less than 3, it was being freed and set to NULL. Once the defer executes on function return, the same address we already freed will be passed again.

We observed this while upgrading libbpfgo in Parca Agent (https://github.com/parca-dev/parca-agent/pull/1599).

Test Plan
=========

Verified it's a double free with ASAN

```
=================================================================
==171270==ERROR: AddressSanitizer: attempting double-free on 0x602000000010 in thread T14:
    #0 0x4d6e68 in __interceptor_free.part.0 asan_malloc_linux.cpp.o
    #1 0x3004be2 in _cgo_38fdf0a0bedf_Cfunc_free (/home/javierhonduco/code/parca-agent/dist/parca-agent+0x3004be2) (BuildId: aebc1e250e9da366a49de9206c528fb67b730e0b)
    #2 0x58bac3 in runtime.asmcgocall.abi0 runtime/asm_amd64.s:848

0x602000000010 is located 0 bytes inside of 1-byte region [0x602000000010,0x602000000011)
freed by thread T14 here:
    #0 0x4d6e68 in __interceptor_free.part.0 asan_malloc_linux.cpp.o
    #1 0x3004be2 in _cgo_38fdf0a0bedf_Cfunc_free (/home/javierhonduco/code/parca-agent/dist/parca-agent+0x3004be2) (BuildId: aebc1e250e9da366a49de9206c528fb67b730e0b)
    #2 0x58bac3 in runtime.asmcgocall.abi0 runtime/asm_amd64.s:848

previously allocated by thread T14 here:
    #0 0x4d7e37 in __interceptor_malloc (/home/javierhonduco/code/parca-agent/dist/parca-agent+0x4d7e37) (BuildId: aebc1e250e9da366a49de9206c528fb67b730e0b)
    #1 0x2ff3ff2 in _cgo_38fdf0a0bedf_Cfunc__Cmalloc (/home/javierhonduco/code/parca-agent/dist/parca-agent+0x2ff3ff2) (BuildId: aebc1e250e9da366a49de9206c528fb67b730e0b)
    #2 0x58bac3 in runtime.asmcgocall.abi0 runtime/asm_amd64.s:848
```

And that there are no issues with this patch applied, both while running the Agent with and without ASAN as well as while running the cpu profiling integration tests which exercise this code path.