### PR TITLE
Expose libbpf_num_possible_cpus

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -2089,3 +2089,11 @@ func BPFProgramTypeIsSupported(progType BPFProgType) (bool, error) {
 	}
 	return cSupported == 1, nil
 }
+
+func NumPossibleCPUs() (int, error) {
+	numCPUs, _ := C.libbpf_num_possible_cpus()
+	if numCPUs < 0 {
+		return 0, fmt.Errorf("failed to retrieve the number of CPUs")
+	}
+	return int(numCPUs), nil
+}


### PR DESCRIPTION
To fetch the number of "possible" (`/sys/devices/system/cpu/possible`) CPUs.

This is needed in various PERCPU structures to compute the value size. More details in https://github.com/parca-dev/parca-agent/issues/1696#issuecomment-1568736923

Fixes: https://github.com/aquasecurity/libbpfgo/issues/195