### PR TITLE
error: consider errno as a return value

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -2091,9 +2091,9 @@ func BPFProgramTypeIsSupported(progType BPFProgType) (bool, error) {
 }
 
 func NumPossibleCPUs() (int, error) {
-	numCPUs, _ := C.libbpf_num_possible_cpus()
+	numCPUs, errC := C.libbpf_num_possible_cpus()
 	if numCPUs < 0 {
-		return 0, fmt.Errorf("failed to retrieve the number of CPUs")
+		return 0, fmt.Errorf("failed to retrieve the number of CPUs: %w", errC)
 	}
 	return int(numCPUs), nil
 }


### PR DESCRIPTION
CGo provide us a way to get errno value from C code as a return value, so it's always a good idea to make use of it.