### PR TITLE
fix: vagrant image install

### DIFF
--- a/builder/Vagrantfile-ubuntu
+++ b/builder/Vagrantfile-ubuntu
@@ -17,19 +17,11 @@ VM_SOURCE = "/vagrant"
 Vagrant.configure("2") do |config|
   case ARCH
   when "amd64"
-    config.vm.box = "generic/ubuntu2204"
+    config.vm.box = "ubuntu/jammy64"
   when "arm64"
-    # unique 22.04 arm64 box available to date
-    # sha256sum c209ab013280d3cd26a344def60b7b19fbb427de904ea285057d94ca6ac82dd5
-    # - http://old-releases.ubuntu.com/releases/jammy/SHA256SUMS
-    # - http://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04-live-server-arm64.iso
-    # - https://gitlab.com/jnh3/m1-baseboxes/-/blob/main/ubuntu/ubuntu-22.04-arm64.pkr.hcl#L11-16
-    config.vm.box = "jharoian3/ubuntu-22.04-arm64"
+    config.vm.box = "bento/ubuntu-22.04-arm64"
   end
-  
-  config.vm.hostname = VM_NAME
-  config.vm.synced_folder "./", "#{VM_SOURCE}"
-  
+
   case HOSTOS
   when "Linux"
     config.vm.provider "virtualbox" do |vb|
@@ -42,29 +34,13 @@ Vagrant.configure("2") do |config|
       prl.name = VM_NAME
     end
   end
-  
-  setup_ssh(config)
-    
-  config.vm.provision :shell, inline: "echo INFO: Starting Provision"
 
-  config.vm.provision :shell, inline: "ARCH=#{ARCH} #{VM_SOURCE}/builder/prepare-ubuntu.sh"
+  config.vm.hostname = VM_NAME
+  config.vm.synced_folder "./", "#{VM_SOURCE}"
 
-  config.vm.provision :shell, inline: "echo INFO: Provision finished, now connect via ssh"
-end
-
-def setup_ssh(config)
   config.ssh.extra_args = ["-t", "cd #{VM_SOURCE}; bash --login"]
 
-  # workaround for ubuntu 22.04 disabled ssh-rsa support
-  # - https://it-jog.com/khow/vag/vaguperror-ubuntu2204
-  if ARGV[0] == "up" then
-    config.ssh.insert_key = false
-    config.ssh.private_key_path = nil
-    config.ssh.username = "vagrant"
-    config.ssh.password = "vagrant"
-  end
-  config.vm.provision "shell", inline: <<-SHELL
-     sudo echo PubkeyAcceptedAlgorithms +ssh-rsa >> /etc/ssh/sshd_config
-     sudo sudo systemctl restart sshd
-  SHELL
+  config.vm.provision :shell, inline: "echo INFO: Starting Provision"
+  config.vm.provision :shell, inline: "ARCH=#{ARCH} #{VM_SOURCE}/builder/prepare-ubuntu.sh"
+  config.vm.provision :shell, inline: "echo INFO: Provision finished, now connect via ssh"
 end


### PR DESCRIPTION
linux-tools-generic install was failing on generic/ubuntu2204 image.

- Change amd64 to ubuntu/jammy64.
- Change arm64 to bento/ubuntu-22.04-arm64
- Remove ssh workaround setting (not needed for jammy64).