### PR TITLE
Add missing API to utilize map of maps

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -196,4 +196,39 @@ void bpf_object_open_opts_free(struct bpf_object_open_opts *opts)
     free(opts);
 }
 
+struct bpf_map_create_opts *bpf_map_create_opts_new(__u32 btf_fd,
+                                                    __u32 btf_key_type_id,
+                                                    __u32 btf_value_type_id,
+                                                    __u32 btf_vmlinux_value_type_id,
+                                                    __u32 inner_map_fd,
+                                                    __u32 map_flags,
+                                                    __u64 map_extra,
+                                                    __u32 numa_node,
+                                                    __u32 map_ifindex)
+{
+    struct bpf_map_create_opts *opts;
+    opts = calloc(1, sizeof(*opts));
+    if (!opts) {
+        return NULL;
+    }
+
+    opts->sz = sizeof(*opts);
+    opts->btf_fd = btf_fd;
+    opts->btf_key_type_id = btf_key_type_id;
+    opts->btf_value_type_id = btf_value_type_id;
+    opts->btf_vmlinux_value_type_id = btf_vmlinux_value_type_id;
+    opts->inner_map_fd = inner_map_fd;
+    opts->map_flags = map_flags;
+    opts->map_extra = map_extra;
+    opts->numa_node = numa_node;
+    opts->map_ifindex = map_ifindex;
+
+    return opts;
+}
+
+void bpf_map_create_opts_free(struct bpf_map_create_opts *opts)
+{
+    free(opts);
+}
+
 #endif

--- a/selftest/common/run-5.8.sh
+++ b/selftest/common/run-5.8.sh
@@ -2,8 +2,8 @@
 
 # SETTINGS
 
-TEST=$(dirname $0)/$1
-TIMEOUT=5
+TEST=$(dirname $0)/$1  # execute
+TIMEOUT=10             # seconds
 
 # COMMON
 

--- a/selftest/common/run-warn-bt-5.4.sh
+++ b/selftest/common/run-warn-bt-5.4.sh
@@ -2,8 +2,8 @@
 
 # SETTINGS
 
-TEST=$(dirname $0)/$1
-TIMEOUT=5
+TEST=$(dirname $0)/$1  # execute
+TIMEOUT=10             # seconds
 
 # COMMON
 

--- a/selftest/common/run.sh
+++ b/selftest/common/run.sh
@@ -2,8 +2,8 @@
 
 # SETTINGS
 
-TEST=$(dirname $0)/$1	# execute
-TIMEOUT=5			# seconds
+TEST=$(dirname $0)/$1  # execute
+TIMEOUT=10             # seconds
 
 # COMMON
 

--- a/selftest/create-map/main.go
+++ b/selftest/create-map/main.go
@@ -3,6 +3,7 @@ package main
 import "C"
 
 import (
+	"encoding/binary"
 	"fmt"
 	"log"
 	"os"
@@ -20,9 +21,6 @@ import (
 // use them as a normal map there as those operations only require
 // a file descriptor.
 
-// You can update values in the map from userspace, but currently
-// can't retrieve values outright.
-
 // For example:
 // https://elixir.bootlin.com/linux/latest/source/samples/bpf/fds_example.c
 // https://elixir.bootlin.com/linux/latest/source/tools/testing/selftests/bpf/test_maps.c
@@ -37,20 +35,249 @@ func main() {
 	defer bpfModule.Close()
 
 	bpfModule.BPFLoadObject()
-	opts := bpf.BPFMapCreateOpts{}
-	opts.Size = uint64(unsafe.Sizeof(opts))
 
-	m, err := bpf.CreateMap(bpf.MapTypeHash, "foobar", 4, 4, 420, nil)
+	keySize := 4
+	valueSize := 4
+	maxEntries := 4
+
+	// CreateMap()
+	createdMapName1 := "created_1"
+	opts1 := &bpf.BPFMapCreateOpts{}
+	createdMap1, err := bpf.CreateMap(bpf.MapTypeHash, createdMapName1, keySize, valueSize, maxEntries, opts1)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	createdOuterMapName2 := "created_outer_2"
+	opts2 := &bpf.BPFMapCreateOpts{
+		InnerMapFD: uint32(createdMap1.FileDescriptor()),
+	}
+	createdOuterMap2, err := bpf.CreateMap(bpf.MapTypeHashOfMaps, createdOuterMapName2, keySize, valueSize, maxEntries, opts2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Update()
 	key1 := uint32(1)
 	value1 := uint32(55)
-	key1Unsafe := unsafe.Pointer(&key1)
-	value1Unsafe := unsafe.Pointer(&value1)
-	err = m.Update(key1Unsafe, value1Unsafe)
+	key1Pointer := unsafe.Pointer(&key1)
+	value1Pointer := unsafe.Pointer(&value1)
+	err = createdMap1.Update(key1Pointer, value1Pointer)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// UpdateValueFlags()
+	flags := bpf.MapFlag(0)
+	err = createdMap1.UpdateValueFlags(key1Pointer, value1Pointer, flags)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// GetValue()
+	readValue, err := createdMap1.GetValue(key1Pointer)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if endian().Uint32(readValue) != value1 {
+		log.Fatal("map value not equal to expected value.")
+	}
+
+	// GetValueFlags()
+	flags = bpf.MapFlag(0)
+	readValueFlags, err := createdMap1.GetValueFlags(key1Pointer, flags)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if endian().Uint32(readValueFlags) != value1 {
+		log.Fatal("map value not equal to expected value.")
+	}
+
+	// GetValueReadInto() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	readValueReadInto := make([]byte, valueSize)
+	err = createdMap1.GetValueReadInto(key1Pointer, &readValueReadInto)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+
+	// UpdateBatch()
+	// GetValueBatch()
+	// GetValueAndDeleteBatch()
+	// DeleteKeyBatch()
+
+	// DeleteKey()
+	err = createdMap1.DeleteKey(key1Pointer)
+	if err != nil {
+		log.Fatal(err)
+	}
+	readValue, err = createdMap1.GetValue(key1Pointer)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+
+	// Name()
+	if createdMap1.Name() != createdMapName1 {
+		log.Fatal("map name not equal to expected name.")
+	}
+	if createdOuterMap2.Name() != createdOuterMapName2 {
+		log.Fatal("map name not equal to expected name.")
+	}
+
+	// Type()
+	if createdMap1.Type() != bpf.MapTypeHash {
+		log.Fatal("map type not equal to expected type.")
+	}
+	if createdOuterMap2.Type() != bpf.MapTypeHashOfMaps {
+		log.Fatal("map type not equal to expected type.")
+	}
+
+	// SetType() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.SetType(bpf.MapTypeArray)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+	err = createdOuterMap2.SetType(bpf.MapTypeArray)
+	if err == nil {
+		log.Fatal(err)
+	}
+
+	// Pin()
+	createdMap1PinPath := "/sys/fs/bpf/" + createdMapName1
+	err = createdMap1.Pin(createdMap1PinPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	createOuterMap2PinPath := "/sys/fs/bpf/" + createdOuterMapName2
+	err = createdOuterMap2.Pin(createOuterMap2PinPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// PinPath() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	if createdMap1.PinPath() != "" {
+		log.Fatal("map pin path not equal to expected pin path.")
+	}
+
+	// IsPinned() is unavailable for maps created with CreateMap(),
+	// so this should return always false.
+	if createdMap1.IsPinned() {
+		log.Fatal("IsPinned() should return false.")
+	}
+
+	// UnPin()
+	err = createdMap1.Unpin(createdMap1PinPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = createdOuterMap2.Unpin(createOuterMap2PinPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// SetPinPath() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.SetPinPath(createdMap1PinPath)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+	err = createdOuterMap2.SetPinPath(createOuterMap2PinPath)
+	if err == nil {
+		log.Fatal(err)
+	}
+
+	// SetInnerMap() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.SetInnerMap(createdMap1)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+
+	// Resize() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.Resize(8)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+
+	// GetMaxEntries()
+	if createdMap1.GetMaxEntries() != uint32(maxEntries) {
+		log.Fatal("map max entries not equal to expected max entries.")
+	}
+	if createdOuterMap2.GetMaxEntries() != uint32(maxEntries) {
+		log.Fatal("map max entries not equal to expected max entries.")
+	}
+
+	// FileDescriptor()
+	if createdMap1.FileDescriptor() <= 0 {
+		log.Fatal("map file descriptor not greater than 0.")
+	}
+	if createdOuterMap2.FileDescriptor() <= 0 {
+		log.Fatal("map file descriptor not greater than 0.")
+	}
+
+	// KeySize()
+	if createdMap1.KeySize() != keySize {
+		log.Fatal("map key size not equal to expected key size.")
+	}
+	if createdOuterMap2.KeySize() != keySize {
+		log.Fatal("map key size not equal to expected key size.")
+	}
+
+	// ValueSize()
+	if createdMap1.ValueSize() != valueSize {
+		log.Fatal("map value size not equal to expected value size.")
+	}
+	if createdOuterMap2.ValueSize() != valueSize {
+		log.Fatal("map value size not equal to expected value size.")
+	}
+
+	// SetValueSize() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.SetValueSize(8)
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+
+	// GetInfoByFD()
+	info, err := createdMap1.GetInfoByFD()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if info.Type != bpf.MapTypeHash {
+		log.Fatal("map type not equal to expected type.")
+	}
+	if info.KeySize != uint32(keySize) {
+		log.Fatal("map key size not equal to expected key size.")
+	}
+	if info.ValueSize != uint32(valueSize) {
+		log.Fatal("map value size not equal to expected value size.")
+	}
+	if info.MaxEntries != uint32(maxEntries) {
+		log.Fatal("map max entries not equal to expected max entries.")
+	}
+	if info.Name != createdMapName1 {
+		log.Fatal("map name not equal to expected name.")
+	}
+
+	// Reload() is unavailable for maps created with CreateMap(),
+	// so this should fail.
+	err = createdMap1.Reload()
+	if err == nil {
+		log.Fatal("this should have failed")
+	}
+}
+
+func endian() binary.ByteOrder {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
 }

--- a/selftest/global-variable/main.go
+++ b/selftest/global-variable/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -60,7 +61,8 @@ func main() {
 	if err != nil {
 		exitWithErr(err)
 	}
-	if _, err := prog.AttachKprobe("__x64_sys_mmap"); err != nil {
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	if _, err := prog.AttachKprobe(funcName); err != nil {
 		exitWithErr(err)
 	}
 
@@ -95,4 +97,15 @@ func main() {
 
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/map-of-maps/Makefile
+++ b/selftest/map-of-maps/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/map-of-maps/go.mod
+++ b/selftest/map-of-maps/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/libbpfgo/selftest/map-of-maps
+
+go 1.18
+
+require github.com/aquasecurity/libbpfgo v0.4.7-libbpf-1.2.0-b2e29a1
+
+replace github.com/aquasecurity/libbpfgo => ../../

--- a/selftest/map-of-maps/go.sum
+++ b/selftest/map-of-maps/go.sum
@@ -1,0 +1,4 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/selftest/map-of-maps/main.bpf.c
+++ b/selftest/map-of-maps/main.bpf.c
@@ -1,0 +1,38 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} inner_hash_0 SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __array(values, typeof(inner_hash_0));
+} outer_hash_0 SEC(".maps") = {
+    .values =
+        {
+            &inner_hash_0,
+        },
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} outer_hash_1 SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} outer_array_2 SEC(".maps");
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-of-maps/main.go
+++ b/selftest/map-of-maps/main.go
@@ -1,0 +1,377 @@
+package main
+
+import "C"
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+	"unsafe"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+// This selftest deals with interactions involving hash maps and an array of maps.
+// It utilizes the functions CreateMap(), SetInnerMap(), GetMapByID(), GetBTFFDByID()
+// and Reload().
+
+func main() {
+	// In this test scenario, we are employing two outer BPF map types, specifically
+	// BPF_MAP_TYPE_HASH_OF_MAPS and BPF_MAP_TYPE_ARRAY_OF_MAPS, referred to as
+	// "outer_hash" and "outer_array" respectively, which are defined in the BPF
+	// object file main.bpf.o. There is one other outer map created in userland,
+	// referred to as "outer_hash_3", which is of type BPF_MAP_TYPE_HASH_OF_MAPS.
+	//
+	// In this case, the purpose of utilizing these outer BPF maps is to store
+	// inner BPF map of type BPF_MAP_TYPE_HASH as entries.
+
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	//
+	// Get BPF object outer maps by name.
+	//
+
+	// hash
+	outerHashMap0, err := bpfModule.GetMap("outer_hash_0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// hash
+	outerHashMap1, err := bpfModule.GetMap("outer_hash_1")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// array
+	outerArrayMap2, err := bpfModule.GetMap("outer_array_2")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// When creating an outer map, an inner map instance is utilized to initialize
+	// the metadata that the outer map holds about its inner maps.
+
+	// hash metadata map (dummy)
+	metadataInnerHashMap, err := bpf.CreateMap(bpf.MapTypeHash, "metadata_inner_hash", 4, 4, 420, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := outerHashMap1.SetInnerMap(metadataInnerHashMap); err != nil {
+		log.Fatal(err)
+	}
+	if err := outerArrayMap2.SetInnerMap(metadataInnerHashMap); err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Load the BPF object and reload the outer maps not defined in the BPF object.
+	//
+
+	bpfModule.BPFLoadObject()
+
+	// The reload call is needed to update the outer BPFMap internal fd value,
+	// otherwise it will still be -1 as the internal fields of this object are
+	// not updated by the BPFLoadObject call.
+
+	// hash
+	// NOTE: This map is already created in the BPF object file, so other way to
+	// use it without concerns is to call bpfMod.GetMap("outer_hash_0") after the BPFLoadObject call.
+	if err := outerHashMap0.Reload(); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash
+	if err := outerHashMap1.Reload(); err != nil {
+		log.Fatal(err)
+	}
+
+	// array
+	if err := outerArrayMap2.Reload(); err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Create outer map not defined in the BPF object.
+	//
+
+	opts := &bpf.BPFMapCreateOpts{
+		InnerMapFD: uint32(metadataInnerHashMap.FileDescriptor()),
+	}
+	// Create a new outer map (not defined in BPF object file).
+	outerHashMap3, err := bpf.CreateMap(bpf.MapTypeHashOfMaps, "outer_hash_3", 4, 4, 1, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Close metadata inner map.
+	//
+
+	// It is important to note that the inner map has a distinct lifetime from the outer map.
+	// Once the outer map is successfully created, the initialization data from the inner map is no
+	// longer required, and the inner map can be safely deleted independently of the outer map.
+	if err := syscall.Close(metadataInnerHashMap.FileDescriptor()); err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Create/get inner maps.
+	//
+
+	// hash map 0 (used for hash outer map 0)
+	// NOTE: This map is already created in the BPF object file.
+	innerHashMap0, err := bpfModule.GetMap("inner_hash_0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	info, err := innerHashMap0.GetInfoByFD()
+	if err != nil {
+		log.Fatal(err)
+	}
+	btfFD, err := bpf.GetBTFFDByID(info.BTFID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	opts = &bpf.BPFMapCreateOpts{
+		BtfFD:                 uint32(btfFD),
+		BtfKeyTypeID:          info.BTFKeyTypeID,
+		BtfValueTypeID:        info.BTFValueTypeID,
+		BtfVmlinuxValueTypeID: info.BTFVmlinuxValueTypeID,
+		MapFlags:              info.MapFlags,
+	}
+
+	// hash map 1 (used for hash outer map 1)
+	// this uses opts with info from innerHashMap0 to have the same BTF
+	innerHashMap1, err := bpf.CreateMap(bpf.MapTypeHash, "inner_hash_1", 4, 4, 420, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// hash map 2 (used for array outer map)
+	// this does not use opts, so it will have no BTF
+	innerHashMap2, err := bpf.CreateMap(bpf.MapTypeHash, "inner_hash_2", 4, 4, 420, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// hash map 3 (used for hash outer map 2)
+	// this does not use opts, so it will have no BTF
+	innerHashMap3, err := bpf.CreateMap(bpf.MapTypeHash, "inner_hash_3", 4, 4, 420, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Insert into inner maps.
+	//
+
+	// hash map 0 (used for hash outer map 0)
+	innerHashKey0 := uint32(0)
+	innerHashValue0 := uint32(33)
+	innerHashKeyPointer0 := unsafe.Pointer(&innerHashKey0)
+	innerHashValuePointer0 := unsafe.Pointer(&innerHashValue0)
+	if err := innerHashMap0.Update(innerHashKeyPointer0, innerHashValuePointer0); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash map 1 (used for hash outer map 1)
+	innerHashKey1 := uint32(1)
+	innerHashValue1 := uint32(42)
+	innerHashKeyPointer1 := unsafe.Pointer(&innerHashKey1)
+	innerHashValuePointer1 := unsafe.Pointer(&innerHashValue1)
+	if err := innerHashMap1.Update(innerHashKeyPointer1, innerHashValuePointer1); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash map 2 (used for array outer map)
+	innerHashKey2 := uint32(2)
+	innerHashValue2 := uint32(51)
+	innerHashKeyPointer2 := unsafe.Pointer(&innerHashKey2)
+	innerHashValuePointer2 := unsafe.Pointer(&innerHashValue2)
+	if err := innerHashMap2.Update(innerHashKeyPointer2, innerHashValuePointer2); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash map 3 (used for hash outer map 2)
+	innerHashKey3 := uint32(3)
+	innerHashValue3 := uint32(60)
+	innerHashKeyPointer3 := unsafe.Pointer(&innerHashKey3)
+	innerHashValuePointer3 := unsafe.Pointer(&innerHashValue3)
+	if err := innerHashMap3.Update(innerHashKeyPointer3, innerHashValuePointer3); err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Insert inner into outer maps.
+	//
+
+	// NOTE: The inner map ID is not the same as the inner map FD.
+	//
+	// The inner map FD is passed as the value to the outer map entry.
+	// However what is really stored is the inner map ID. Remember that when doing lookups.
+
+	// hash (innerHashMap0)
+	// NOTE: This map is already inserted in the respective outer via BPF object file.
+	outerHashKey0 := uint32(0)
+	outerHashKeyPointer0 := unsafe.Pointer(&outerHashKey0)
+
+	// hash (store innerHashMap1)
+	outerHashKey1 := uint32(1)
+	outerHashValue1 := uint32(innerHashMap1.FileDescriptor())
+	outerHashKeyPointer1 := unsafe.Pointer(&outerHashKey1)
+	outerHashValuePointer1 := unsafe.Pointer(&outerHashValue1)
+	if err := outerHashMap1.Update(outerHashKeyPointer1, outerHashValuePointer1); err != nil {
+		log.Fatal(err)
+	}
+
+	// array (store innerHashMap2)
+	outerArrKey2 := uint32(0) // index 0
+	outerArrValue2 := uint32(innerHashMap2.FileDescriptor())
+	outerArrKeyPointer2 := unsafe.Pointer(&outerArrKey2)
+	outerArrValuePointer2 := unsafe.Pointer(&outerArrValue2)
+	if err := outerArrayMap2.Update(outerArrKeyPointer2, outerArrValuePointer2); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash (store innerHashMap3)
+	outerHashKey3 := uint32(3)
+	outerHashValue3 := uint32(innerHashMap3.FileDescriptor())
+	outerHashKeyPointer3 := unsafe.Pointer(&outerHashKey3)
+	outerHashValuePointer3 := unsafe.Pointer(&outerHashValue3)
+	if err := outerHashMap3.Update(outerHashKeyPointer3, outerHashValuePointer3); err != nil {
+		log.Fatal(err)
+	}
+
+	//
+	// Read from outer and then inner maps, respectively.
+	//
+
+	// hash map 0 (read from outerHashMap0)
+	outerHashVal0, err := outerHashMap0.GetValue(outerHashKeyPointer0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	innerHashMapId0 := endian().Uint32(outerHashVal0)
+	readHashInnerMap0, err := bpf.GetMapByID(innerHashMapId0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	readHashInnerValue0, err := readHashInnerMap0.GetValue(innerHashKeyPointer0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if endian().Uint32(readHashInnerValue0) != innerHashValue0 {
+		log.Fatal("Inner map value not equal to expected value.")
+	}
+
+	// hash map 1 (read from outerHashMap)
+	outerHashVal1, err := outerHashMap1.GetValue(outerHashKeyPointer1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	innerHashMapId1 := endian().Uint32(outerHashVal1)
+	readHashInnerMap1, err := bpf.GetMapByID(innerHashMapId1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	readHashInnerValue1, err := readHashInnerMap1.GetValue(innerHashKeyPointer1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if endian().Uint32(readHashInnerValue1) != innerHashValue1 {
+		log.Fatal("Inner map value not equal to expected value.")
+	}
+
+	// hash map 2 (read from outerArrayMap1)
+	outerArrVal, err := outerArrayMap2.GetValue(outerArrKeyPointer2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	innerHashMapId2 := endian().Uint32(outerArrVal)
+	readHashInnerMap2, err := bpf.GetMapByID(innerHashMapId2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	readHashInnerValue2, err := readHashInnerMap2.GetValue(innerHashKeyPointer2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if endian().Uint32(readHashInnerValue2) != innerHashValue2 {
+		log.Fatal("Inner map value not equal to expected value.")
+	}
+
+	// hash map 3 (read from outerHashMap2)
+	outerHashVal2, err := outerHashMap3.GetValue(outerHashKeyPointer3)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	innerHashMapId3 := endian().Uint32(outerHashVal2)
+	readHashInnerMap3, err := bpf.GetMapByID(innerHashMapId3)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	readHashInnerValue3, err := readHashInnerMap3.GetValue(innerHashKeyPointer3)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if endian().Uint32(readHashInnerValue3) != innerHashValue3 {
+		log.Fatal("Inner map value not equal to expected value.")
+	}
+
+	//
+	// Delete from outer maps.
+	//
+
+	// hash 0
+	if err := outerHashMap0.DeleteKey(outerHashKeyPointer0); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash 1
+	if err := outerHashMap1.DeleteKey(outerHashKeyPointer1); err != nil {
+		log.Fatal(err)
+	}
+
+	// array 2
+	if err := outerArrayMap2.DeleteKey(outerArrKeyPointer2); err != nil {
+		log.Fatal(err)
+	}
+
+	// hash 3
+	if err := outerHashMap3.DeleteKey(outerHashKeyPointer3); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func endian() binary.ByteOrder {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
+}

--- a/selftest/map-of-maps/run.sh
+++ b/selftest/map-of-maps/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 	"time"
 	"unsafe"
 
@@ -79,7 +80,8 @@ func main() {
 	value2Unsafe := unsafe.Pointer(&value2[0])
 	testerMap.Update(key2Unsafe, value2Unsafe)
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -115,4 +117,15 @@ func main() {
 
 	pb.Stop()
 	pb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/multiple-objects/first.bpf.c
+++ b/selftest/multiple-objects/first.bpf.c
@@ -8,7 +8,11 @@
 #include "map.bpf.h"
 
 // Large instruction count
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_openat")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_openat")
+#endif
 int openat_fentry(struct pt_regs* ctx)
 {
     bpf_printk("openat (multiple objects-1)");

--- a/selftest/multiple-objects/second.bpf.c
+++ b/selftest/multiple-objects/second.bpf.c
@@ -8,7 +8,11 @@
 #include "map.bpf.h"
 
 // Large instruction count
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs* ctx)
 {
     bpf_printk("Mmap (multiple objects-2)");

--- a/selftest/object-iterator/main.bpf.c
+++ b/selftest/object-iterator/main.bpf.c
@@ -19,19 +19,31 @@ struct {
     __uint(max_entries, 1);
 } two SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     return 0;
 }
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_execve")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_execve")
+#endif
 int execve_fentry(struct pt_regs *ctx)
 {
     return 0;
 }
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_execveat")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_execveat")
+#endif
 int execveat_fentry(struct pt_regs *ctx)
 {
     return 0;

--- a/selftest/percpu/main.bpf.c
+++ b/selftest/percpu/main.bpf.c
@@ -12,7 +12,11 @@ struct {
     __type(value, __u64);
 } percpu_hash SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     __u32 key = 0;

--- a/selftest/perfbuffers/main.go
+++ b/selftest/perfbuffers/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 
 	"encoding/binary"
 	"fmt"
@@ -49,7 +50,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -91,4 +93,15 @@ recvLoop:
 	pb.Close()
 	pb.Close()
 	pb.Stop()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/ringbuffers/main.go
+++ b/selftest/ringbuffers/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -50,7 +51,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -91,4 +93,15 @@ recvLoop:
 	rb.Close()
 	rb.Close()
 	rb.Stop()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/set-attach/main.go
+++ b/selftest/set-attach/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"encoding/binary"
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -32,7 +33,8 @@ func main() {
 	// prog.SetProgramType(bpf.BPFProgTypeTracing)
 	prog.SetAttachType(bpf.BPFAttachTypeTraceFentry)
 
-	err = prog.SetAttachTarget(0, "__x64_sys_mmap")
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	err = prog.SetAttachTarget(0, funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -78,4 +80,15 @@ recvLoop:
 	}
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/spinlocks/main.bpf.c
+++ b/selftest/spinlocks/main.bpf.c
@@ -26,7 +26,11 @@ struct {
     __uint(max_entries, 1 << 24);
 } events SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     int *process;

--- a/selftest/tracing/main.bpf.c
+++ b/selftest/tracing/main.bpf.c
@@ -11,7 +11,11 @@ struct {
 } events SEC(".maps");
 long ringbuffer_flags = 0;
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     int *process;

--- a/selftest/tracing/main.go
+++ b/selftest/tracing/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"encoding/binary"
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -34,7 +35,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	sym, err := m.GetSymbolByName("system", "__x64_sys_mmap")
+	funcName := "__" + ksymArch() + "_sys_mmap"
+	sym, err := m.GetSymbolByName("system", funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -89,4 +91,15 @@ recvLoop:
 
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/uprobe/run.sh
+++ b/selftest/uprobe/run.sh
@@ -2,8 +2,8 @@
 
 # SETTINGS
 
-TEST=$(dirname $0)/$1	# execute
-TIMEOUT=5			# seconds
+TEST=$(dirname $0)/$1  # execute
+TIMEOUT=10             # seconds
 
 CTEST=$(dirname $0)/ctest
 GOTEST=$(dirname $0)/gotest


### PR DESCRIPTION
Close: #93
Context: #213 

---

commit 108b24a6844bfe551db7e3919e6a22bd2e3dde0e
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Mon Jul 24 14:06:23 2023 -0300

    chore: improve create-map selftest

commit 7c0bb3e9054e3f82b1026f2169efdccfae8a6e7c
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Mon Jul 24 13:46:11 2023 -0300

    feat: add missing API to utilize map of maps
    
    In this commit, the libbpfgo.go file undergoes significant changes,
    primarily focused on introducing and updating functions related to BPF
    maps. The main feature added is the capability to utilize "map of maps",
    which involves creating, managing, and interacting with nested maps.
    
    Added Functions:
    
        Reload
        GetMapByID
        GetBTFFDByID
        SetInnerMap
        MaxEntries (Note: GetMaxEntries is deprecated)
    
    Updated Functions (to deal with maps returned by CreateMap):
    
        CreateMap
        Name
        Type
        SetType
        KeySize
        ValueSize
        SetValueSize
        Pin
        Unpin
        SetPinPath
        PinPath
        IsPinned
        FileDescriptor
        GetValue
        GetValueFlags
        GetValueReadInto
        Update
        Resize
        GetValueBatch
        GetValueAndDeleteBatch
    
    Miscellaneous:
    
    Aside from the map-related features, this commit also includes various
    minor updates and improves error handling, all of which contribute to
    the overall robustness of the library.
    
    Co-authored-by: Kemal Akkoyun <kakkoyun@gmail.com>

commit 470b7d283f8c96495a00100b71f232f923bcff8b
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Mon Jul 24 12:24:42 2023 -0300

    fix: fix selftests for arm64
    
    Despite the fact that selftests were handling the correct function
    names for arm64, some are still not working due to the fact that arm64
    still does not support generic attaching `bpf_program__attach()`.
    
    ```
    libbpf: prog 'mmap_fentry': failed to attach: ERROR: strerror_r(-524)=22
    failed to attach program: errno 524
    [!] ERROR: test error
    make[1]: *** [Makefile:81: run-static] Error 4
    make[1]: Leaving directory '/vagrant/selftest/percpu'
    ```
    
    `#define ENOTSUPP       524     /* Operation is not supported */`

commit f061588bde722a0b79d3031d6cf9545423ccf564
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Mon Jul 24 12:22:07 2023 -0300

    chore: increase timeout for selftests
