### PR TITLE
Add BPF map reuse function

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -564,6 +564,15 @@ func (b *BPFMap) Type() MapType {
 	return MapType(C.bpf_map__type(b.bpfMap))
 }
 
+func (b *BPFMap) MapReuseFd(fd int) error {
+	errC := C.bpf_map__reuse_fd(b.bpfMap, C.int(fd))
+	if errC != 0 {
+		return fmt.Errorf("could not reuse bpf map fd %d: %w", fd, syscall.Errno(-errC))
+	}
+	b.fd = C.int(fd)
+	return nil
+}
+
 // SetType is used to set the type of a bpf map that isn't associated
 // with a file descriptor already. If the map is already associated
 // with a file descriptor the libbpf API will return error code EBUSY

--- a/selftest/common/common.sh
+++ b/selftest/common/common.sh
@@ -33,7 +33,7 @@ okcontinue()   { okay  "$1";         }
 kern_version() {
   _oper=$1; _version=$2; _notfatal=$3;
   _given=$(($(echo $_version | sed 's:\.::g')))
-  _current=$(($(uname -r | cut -d'.' -f1,2 | sed 's:\.::g')))
+  _current=$(($(uname -r | cut -d'.' -f1,2,3 | sed 's:\.::g')))
 
   [[ "$_version" == "" ]] && errexit "no kernel version given"
 

--- a/selftest/create-map/main.go
+++ b/selftest/create-map/main.go
@@ -36,10 +36,6 @@ func main() {
 	}
 	defer bpfModule.Close()
 
-	bpfModule.BPFLoadObject()
-	opts := bpf.BPFMapCreateOpts{}
-	opts.Size = uint64(unsafe.Sizeof(opts))
-
 	m, err := bpf.CreateMap(bpf.MapTypeHash, "foobar", 4, 4, 420, nil)
 	if err != nil {
 		log.Fatal(err)

--- a/selftest/map-update/main.bpf.c
+++ b/selftest/map-update/main.bpf.c
@@ -17,6 +17,13 @@ struct {
 } tester SEC(".maps");
 
 struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, struct value);
+    __uint(max_entries, 1 << 24);
+} tester_reused SEC(".maps");
+
+struct {
     __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
     __uint(key_size, sizeof(u32));
     __uint(value_size, sizeof(u32));

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -87,6 +87,23 @@ func main() {
 		os.Exit(-1)
 	}
 
+	testerMap2, err := bpfModule.GetMap("tester_reused")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	err = testerMap2.MapReuseFd(testerMap.FileDescriptor())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
 	eventsChannel := make(chan []byte)
 	lostChannel := make(chan uint64)
 	pb, err := bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)


### PR DESCRIPTION
Wrap `bpf_map__reuse_fd` to reuse a BPF map accross BPF programs. This
is useful in complex programs that long chains of calls, for example,
via `bpf_tail_call` that may be loaded in different programs and share
state via reused maps.

Why is this useful
=================

Our global state map, called `heap` is shared by multiple programs.
Map reuse will soon become a load loading functionality for Parca Agent.

Test Plan
=========

Added selftest +

```
[javierhonduco@fedora parca-agent]$ sudo bpftool map  | grep heap
3403: percpu_array  name heap  flags 0x0
```

```
2812: perf_event  name walk_user_stacktrace_impl  tag 25cb7e352f197144  gpl
        loaded_at 2023-08-01T16:06:01+0100  uid 0
        xlated 7984B  jited 4827B  memlock 12288B  map_ids 3399,3411,3401,3407,3400,3408,3409,3402,3406,3405,3403
        btf_id 1993
        pids parca-agent(1049424)
        metadata:
                name = "parca-agent (https://github.com/parca-dev/parca-agent)"
2814: perf_event  name profile_cpu  tag 3f2053ff90208ef1  gpl
        loaded_at 2023-08-01T16:06:02+0100  uid 0
        xlated 4368B  jited 2850B  memlock 8192B  map_ids 3411,3404,3399,3401,3408,3409,3405,3407,3403,3402
        btf_id 1993
        pids parca-agent(1049424)
        metadata:
                name = "parca-agent (https://github.com/parca-dev/parca-agent)"
2816: perf_event  name walk_ruby_stack  tag 97bb3ee23c47e22d  gpl
        loaded_at 2023-08-01T16:06:02+0100  uid 0
        xlated 87600B  jited 56572B  memlock 98304B  map_ids 3413,3414,3419,3415,3399,3403,3420,3417,3418
        btf_id 1994
        pids parca-agent(1049424)
```

We are thoroughly testing it, across multiple kernels and with ASAN
enabled, too.

If there were any problems in the future we will quickly notice them and
will be happy to submit bugfixes.
