### PR TITLE
fix(selftest): handle arm64 function names

### DIFF
--- a/selftest/global-variable/main.go
+++ b/selftest/global-variable/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -60,7 +61,8 @@ func main() {
 	if err != nil {
 		exitWithErr(err)
 	}
-	if _, err := prog.AttachKprobe("__x64_sys_mmap"); err != nil {
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	if _, err := prog.AttachKprobe(funcName); err != nil {
 		exitWithErr(err)
 	}
 
@@ -95,4 +97,15 @@ func main() {
 
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/iter/main.go
+++ b/selftest/iter/main.go
@@ -51,7 +51,7 @@ func main() {
 	thisPid := syscall.Getpid()
 	pids := make(map[int]*os.Process, 0)
 	for i := 0; i < totalExecs; i++ {
-		cmd := exec.Command("ping", "-w", "15", "8.8.8.8")
+		cmd := exec.Command("ping", "-w", "10", "8.8.8.8")
 		err := cmd.Start()
 		if err != nil {
 			exitWithErr(err)

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 	"time"
 	"unsafe"
 
@@ -79,7 +80,8 @@ func main() {
 	value2Unsafe := unsafe.Pointer(&value2[0])
 	testerMap.Update(key2Unsafe, value2Unsafe)
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -115,4 +117,15 @@ func main() {
 
 	pb.Stop()
 	pb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/multiple-objects/first.bpf.c
+++ b/selftest/multiple-objects/first.bpf.c
@@ -8,7 +8,11 @@
 #include "map.bpf.h"
 
 // Large instruction count
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_openat")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_openat")
+#endif
 int openat_fentry(struct pt_regs* ctx)
 {
     bpf_printk("openat (multiple objects-1)");

--- a/selftest/multiple-objects/second.bpf.c
+++ b/selftest/multiple-objects/second.bpf.c
@@ -8,7 +8,11 @@
 #include "map.bpf.h"
 
 // Large instruction count
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs* ctx)
 {
     bpf_printk("Mmap (multiple objects-2)");

--- a/selftest/object-iterator/main.bpf.c
+++ b/selftest/object-iterator/main.bpf.c
@@ -19,19 +19,31 @@ struct {
     __uint(max_entries, 1);
 } two SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     return 0;
 }
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_execve")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_execve")
+#endif
 int execve_fentry(struct pt_regs *ctx)
 {
     return 0;
 }
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_execveat")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_execveat")
+#endif
 int execveat_fentry(struct pt_regs *ctx)
 {
     return 0;

--- a/selftest/percpu/main.bpf.c
+++ b/selftest/percpu/main.bpf.c
@@ -12,7 +12,11 @@ struct {
     __type(value, __u64);
 } percpu_hash SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     __u32 key = 0;

--- a/selftest/perfbuffers/main.go
+++ b/selftest/perfbuffers/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 
 	"encoding/binary"
 	"fmt"
@@ -49,7 +50,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -91,4 +93,15 @@ recvLoop:
 	pb.Close()
 	pb.Close()
 	pb.Stop()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/ringbuffers/main.go
+++ b/selftest/ringbuffers/main.go
@@ -4,6 +4,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -50,7 +51,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	_, err = prog.AttachKprobe(funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -91,4 +93,15 @@ recvLoop:
 	rb.Close()
 	rb.Close()
 	rb.Stop()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/set-attach/main.go
+++ b/selftest/set-attach/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"encoding/binary"
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -32,7 +33,8 @@ func main() {
 	// prog.SetProgramType(bpf.BPFProgTypeTracing)
 	prog.SetAttachType(bpf.BPFAttachTypeTraceFentry)
 
-	err = prog.SetAttachTarget(0, "__x64_sys_mmap")
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	err = prog.SetAttachTarget(0, funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -78,4 +80,15 @@ recvLoop:
 	}
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }

--- a/selftest/spinlocks/main.bpf.c
+++ b/selftest/spinlocks/main.bpf.c
@@ -26,7 +26,11 @@ struct {
     __uint(max_entries, 1 << 24);
 } events SEC(".maps");
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     int *process;

--- a/selftest/tracing/main.bpf.c
+++ b/selftest/tracing/main.bpf.c
@@ -11,7 +11,11 @@ struct {
 } events SEC(".maps");
 long ringbuffer_flags = 0;
 
+#ifdef __TARGET_ARCH_amd64
 SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
 int mmap_fentry(struct pt_regs *ctx)
 {
     int *process;

--- a/selftest/tracing/main.go
+++ b/selftest/tracing/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"encoding/binary"
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -34,7 +35,8 @@ func main() {
 		os.Exit(-1)
 	}
 
-	sym, err := m.GetSymbolByName("system", "__x64_sys_mmap")
+	funcName := fmt.Sprintf("__%s_sys_mmap", ksymArch())
+	sym, err := m.GetSymbolByName("system", funcName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
@@ -89,4 +91,15 @@ recvLoop:
 
 	rb.Stop()
 	rb.Close()
+}
+
+func ksymArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		panic("unsupported architecture")
+	}
 }


### PR DESCRIPTION
commit e7932792aaff5ada7eb29232a03563660a54cc1b

    chore(selftest): lower ping timeout to 10 secs
    
    ping command timeout was higher than the iter selftest timeout.

commit 46d619adc84c1ffd0a88593437e11ff3cbe15666

    fix(selftest): handle arm64 function names
    
    Check current architecture and use the correct function names.
    
    Despite the fact that selftests are now handling the right function
    names for arm64, some are still not working due to the fact that arm64
    still does not support generic attaching `bpf_program__attach()`.
    
    Error:
    
    libbpf: prog 'mmap_fentry': failed to attach: ERROR: strerror_r(-524)=22
    failed to attach program: errno 524
    [!] ERROR: test error
    make[1]: *** [Makefile:81: run-static] Error 4
    make[1]: Leaving directory '/vagrant/selftest/percpu'
    
    '#define ENOTSUPP       524     /* Operation is not supported */'
    https://elixir.bootlin.com/linux/latest/source/include/linux/errno.h#L27