### PR TITLE
fix(selftest): use channel for sync

### DIFF
--- a/selftest/perfbuffers/main.go
+++ b/selftest/perfbuffers/main.go
@@ -5,6 +5,7 @@ import "C"
 import (
 	"os"
 	"runtime"
+	"time"
 
 	"encoding/binary"
 	"fmt"
@@ -67,25 +68,31 @@ func main() {
 
 	pb.Poll(300)
 
-	numberOfEventsReceived := 0
+	stop := make(chan struct{})
 
 	go func() {
 		for {
-			syscall.Mmap(999, 999, 999, 1, 1)
+			select {
+			case <-stop:
+				return
+			case b := <-eventsChannel:
+				if binary.LittleEndian.Uint32(b) != 2021 {
+					fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+					os.Exit(-1)
+				}
+			}
 		}
 	}()
-recvLoop:
-	for {
-		b := <-eventsChannel
-		if binary.LittleEndian.Uint32(b) != 2021 {
-			fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
-			os.Exit(-1)
-		}
-		numberOfEventsReceived++
-		if numberOfEventsReceived > 5 {
-			break recvLoop
-		}
+
+	// give some time for the upper goroutine to start
+	time.Sleep(100 * time.Millisecond)
+
+	for sent := 0; sent < 5; sent++ {
+		syscall.Mmap(999, 999, 999, 1, 1)
+		time.Sleep(100 * time.Millisecond)
 	}
+
+	close(stop)
 
 	// Test that it won't cause a panic or block if Stop or Close called multiple times
 	pb.Stop()


### PR DESCRIPTION
Context:
https://github.com/aquasecurity/libbpfgo/pull/349#issuecomment-1662157878
https://github.com/aquasecurity/libbpfgo/pull/350#issuecomment-1662991998

fix(selftest): use channel for sync
    
    attachgenericfd and perfbuffers selftests were using a goroutine without
    any syncronization mechanism.