### PR TITLE
Enum string API

### DIFF
--- a/map-common.go
+++ b/map-common.go
@@ -86,7 +86,13 @@ var mapTypeToString = map[MapType]string{
 }
 
 func (t MapType) String() string {
-	return mapTypeToString[t]
+	str, ok := mapTypeToString[t]
+	if !ok {
+		// MapTypeUnspec must exist in mapTypeToString to avoid infinite recursion.
+		return BPFProgTypeUnspec.String()
+	}
+
+	return str
 }
 
 //

--- a/map-common.go
+++ b/map-common.go
@@ -18,37 +18,37 @@ import (
 type MapType uint32
 
 const (
-	MapTypeUnspec MapType = iota
-	MapTypeHash
-	MapTypeArray
-	MapTypeProgArray
-	MapTypePerfEventArray
-	MapTypePerCPUHash
-	MapTypePerCPUArray
-	MapTypeStackTrace
-	MapTypeCgroupArray
-	MapTypeLRUHash
-	MapTypeLRUPerCPUHash
-	MapTypeLPMTrie
-	MapTypeArrayOfMaps
-	MapTypeHashOfMaps
-	MapTypeDevMap
-	MapTypeSockMap
-	MapTypeCPUMap
-	MapTypeXSKMap
-	MapTypeSockHash
-	MapTypeCgroupStorage
-	MapTypeReusePortSockArray
-	MapTypePerCPUCgroupStorage
-	MapTypeQueue
-	MapTypeStack
-	MapTypeSKStorage
-	MapTypeDevmapHash
-	MapTypeStructOps
-	MapTypeRingbuf
-	MapTypeInodeStorage
-	MapTypeTaskStorage
-	MapTypeBloomFilter
+	MapTypeUnspec              MapType = C.BPF_MAP_TYPE_UNSPEC
+	MapTypeHash                MapType = C.BPF_MAP_TYPE_HASH
+	MapTypeArray               MapType = C.BPF_MAP_TYPE_ARRAY
+	MapTypeProgArray           MapType = C.BPF_MAP_TYPE_PROG_ARRAY
+	MapTypePerfEventArray      MapType = C.BPF_MAP_TYPE_PERF_EVENT_ARRAY
+	MapTypePerCPUHash          MapType = C.BPF_MAP_TYPE_PERCPU_HASH
+	MapTypePerCPUArray         MapType = C.BPF_MAP_TYPE_PERCPU_ARRAY
+	MapTypeStackTrace          MapType = C.BPF_MAP_TYPE_STACK_TRACE
+	MapTypeCgroupArray         MapType = C.BPF_MAP_TYPE_CGROUP_ARRAY
+	MapTypeLRUHash             MapType = C.BPF_MAP_TYPE_LRU_HASH
+	MapTypeLRUPerCPUHash       MapType = C.BPF_MAP_TYPE_LRU_PERCPU_HASH
+	MapTypeLPMTrie             MapType = C.BPF_MAP_TYPE_LPM_TRIE
+	MapTypeArrayOfMaps         MapType = C.BPF_MAP_TYPE_ARRAY_OF_MAPS
+	MapTypeHashOfMaps          MapType = C.BPF_MAP_TYPE_HASH_OF_MAPS
+	MapTypeDevMap              MapType = C.BPF_MAP_TYPE_DEVMAP
+	MapTypeSockMap             MapType = C.BPF_MAP_TYPE_SOCKMAP
+	MapTypeCPUMap              MapType = C.BPF_MAP_TYPE_CPUMAP
+	MapTypeXSKMap              MapType = C.BPF_MAP_TYPE_XSKMAP
+	MapTypeSockHash            MapType = C.BPF_MAP_TYPE_SOCKHASH
+	MapTypeCgroupStorage       MapType = C.BPF_MAP_TYPE_CGROUP_STORAGE
+	MapTypeReusePortSockArray  MapType = C.BPF_MAP_TYPE_REUSEPORT_SOCKARRAY
+	MapTypePerCPUCgroupStorage MapType = C.BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE
+	MapTypeQueue               MapType = C.BPF_MAP_TYPE_QUEUE
+	MapTypeStack               MapType = C.BPF_MAP_TYPE_STACK
+	MapTypeSKStorage           MapType = C.BPF_MAP_TYPE_SK_STORAGE
+	MapTypeDevmapHash          MapType = C.BPF_MAP_TYPE_DEVMAP_HASH
+	MapTypeStructOps           MapType = C.BPF_MAP_TYPE_STRUCT_OPS
+	MapTypeRingbuf             MapType = C.BPF_MAP_TYPE_RINGBUF
+	MapTypeInodeStorage        MapType = C.BPF_MAP_TYPE_INODE_STORAGE
+	MapTypeTaskStorage         MapType = C.BPF_MAP_TYPE_TASK_STORAGE
+	MapTypeBloomFilter         MapType = C.BPF_MAP_TYPE_BLOOM_FILTER
 )
 
 var mapTypeToString = map[MapType]string{

--- a/map-common.go
+++ b/map-common.go
@@ -95,6 +95,10 @@ func (t MapType) String() string {
 	return str
 }
 
+func (t MapType) Name() string {
+	return C.GoString(C.libbpf_bpf_map_type_str(C.enum_bpf_map_type(t)))
+}
+
 //
 // MapFlag
 //

--- a/prog-common.go
+++ b/prog-common.go
@@ -48,6 +48,7 @@ const (
 	BPFProgTypeSyscall
 )
 
+// Deprecated: Convert type directly instead.
 func (b BPFProgType) Value() uint64 { return uint64(b) }
 
 func (b BPFProgType) String() (str string) {

--- a/prog-common.go
+++ b/prog-common.go
@@ -96,6 +96,10 @@ func (t BPFProgType) String() string {
 	return str
 }
 
+func (t BPFProgType) Name() string {
+	return C.GoString(C.libbpf_bpf_prog_type_str(C.enum_bpf_prog_type(t)))
+}
+
 //
 // BPFAttachType
 //
@@ -197,10 +201,14 @@ var bpfAttachTypeToString = map[BPFAttachType]string{
 func (t BPFAttachType) String() string {
 	str, ok := bpfAttachTypeToString[t]
 	if !ok {
-		return "Unspecified"
+		return "BPFAttachType unspecified"
 	}
 
 	return str
+}
+
+func (t BPFAttachType) Name() string {
+	return C.GoString(C.libbpf_bpf_attach_type_str(C.enum_bpf_attach_type(t)))
 }
 
 //

--- a/prog-common.go
+++ b/prog-common.go
@@ -49,47 +49,50 @@ const (
 )
 
 // Deprecated: Convert type directly instead.
-func (b BPFProgType) Value() uint64 { return uint64(b) }
+func (t BPFProgType) Value() uint64 { return uint64(t) }
 
-func (b BPFProgType) String() (str string) {
-	x := map[BPFProgType]string{
-		BPFProgTypeUnspec:                "BPF_PROG_TYPE_UNSPEC",
-		BPFProgTypeSocketFilter:          "BPF_PROG_TYPE_SOCKET_FILTER",
-		BPFProgTypeKprobe:                "BPF_PROG_TYPE_KPROBE",
-		BPFProgTypeSchedCls:              "BPF_PROG_TYPE_SCHED_CLS",
-		BPFProgTypeSchedAct:              "BPF_PROG_TYPE_SCHED_ACT",
-		BPFProgTypeTracepoint:            "BPF_PROG_TYPE_TRACEPOINT",
-		BPFProgTypeXdp:                   "BPF_PROG_TYPE_XDP",
-		BPFProgTypePerfEvent:             "BPF_PROG_TYPE_PERF_EVENT",
-		BPFProgTypeCgroupSkb:             "BPF_PROG_TYPE_CGROUP_SKB",
-		BPFProgTypeCgroupSock:            "BPF_PROG_TYPE_CGROUP_SOCK",
-		BPFProgTypeLwtIn:                 "BPF_PROG_TYPE_LWT_IN",
-		BPFProgTypeLwtOut:                "BPF_PROG_TYPE_LWT_OUT",
-		BPFProgTypeLwtXmit:               "BPF_PROG_TYPE_LWT_XMIT",
-		BPFProgTypeSockOps:               "BPF_PROG_TYPE_SOCK_OPS",
-		BPFProgTypeSkSkb:                 "BPF_PROG_TYPE_SK_SKB",
-		BPFProgTypeCgroupDevice:          "BPF_PROG_TYPE_CGROUP_DEVICE",
-		BPFProgTypeSkMsg:                 "BPF_PROG_TYPE_SK_MSG",
-		BPFProgTypeRawTracepoint:         "BPF_PROG_TYPE_RAW_TRACEPOINT",
-		BPFProgTypeCgroupSockAddr:        "BPF_PROG_TYPE_CGROUP_SOCK_ADDR",
-		BPFProgTypeLwtSeg6Local:          "BPF_PROG_TYPE_LWT_SEG6LOCAL",
-		BPFProgTypeLircMode2:             "BPF_PROG_TYPE_LIRC_MODE2",
-		BPFProgTypeSkReuseport:           "BPF_PROG_TYPE_SK_REUSEPORT",
-		BPFProgTypeFlowDissector:         "BPF_PROG_TYPE_FLOW_DISSECTOR",
-		BPFProgTypeCgroupSysctl:          "BPF_PROG_TYPE_CGROUP_SYSCTL",
-		BPFProgTypeRawTracepointWritable: "BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE",
-		BPFProgTypeCgroupSockopt:         "BPF_PROG_TYPE_CGROUP_SOCKOPT",
-		BPFProgTypeTracing:               "BPF_PROG_TYPE_TRACING",
-		BPFProgTypeStructOps:             "BPF_PROG_TYPE_STRUCT_OPS",
-		BPFProgTypeExt:                   "BPF_PROG_TYPE_EXT",
-		BPFProgTypeLsm:                   "BPF_PROG_TYPE_LSM",
-		BPFProgTypeSkLookup:              "BPF_PROG_TYPE_SK_LOOKUP",
-		BPFProgTypeSyscall:               "BPF_PROG_TYPE_SYSCALL",
+var bpfProgTypeToString = map[BPFProgType]string{
+	BPFProgTypeUnspec:                "BPF_PROG_TYPE_UNSPEC",
+	BPFProgTypeSocketFilter:          "BPF_PROG_TYPE_SOCKET_FILTER",
+	BPFProgTypeKprobe:                "BPF_PROG_TYPE_KPROBE",
+	BPFProgTypeSchedCls:              "BPF_PROG_TYPE_SCHED_CLS",
+	BPFProgTypeSchedAct:              "BPF_PROG_TYPE_SCHED_ACT",
+	BPFProgTypeTracepoint:            "BPF_PROG_TYPE_TRACEPOINT",
+	BPFProgTypeXdp:                   "BPF_PROG_TYPE_XDP",
+	BPFProgTypePerfEvent:             "BPF_PROG_TYPE_PERF_EVENT",
+	BPFProgTypeCgroupSkb:             "BPF_PROG_TYPE_CGROUP_SKB",
+	BPFProgTypeCgroupSock:            "BPF_PROG_TYPE_CGROUP_SOCK",
+	BPFProgTypeLwtIn:                 "BPF_PROG_TYPE_LWT_IN",
+	BPFProgTypeLwtOut:                "BPF_PROG_TYPE_LWT_OUT",
+	BPFProgTypeLwtXmit:               "BPF_PROG_TYPE_LWT_XMIT",
+	BPFProgTypeSockOps:               "BPF_PROG_TYPE_SOCK_OPS",
+	BPFProgTypeSkSkb:                 "BPF_PROG_TYPE_SK_SKB",
+	BPFProgTypeCgroupDevice:          "BPF_PROG_TYPE_CGROUP_DEVICE",
+	BPFProgTypeSkMsg:                 "BPF_PROG_TYPE_SK_MSG",
+	BPFProgTypeRawTracepoint:         "BPF_PROG_TYPE_RAW_TRACEPOINT",
+	BPFProgTypeCgroupSockAddr:        "BPF_PROG_TYPE_CGROUP_SOCK_ADDR",
+	BPFProgTypeLwtSeg6Local:          "BPF_PROG_TYPE_LWT_SEG6LOCAL",
+	BPFProgTypeLircMode2:             "BPF_PROG_TYPE_LIRC_MODE2",
+	BPFProgTypeSkReuseport:           "BPF_PROG_TYPE_SK_REUSEPORT",
+	BPFProgTypeFlowDissector:         "BPF_PROG_TYPE_FLOW_DISSECTOR",
+	BPFProgTypeCgroupSysctl:          "BPF_PROG_TYPE_CGROUP_SYSCTL",
+	BPFProgTypeRawTracepointWritable: "BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE",
+	BPFProgTypeCgroupSockopt:         "BPF_PROG_TYPE_CGROUP_SOCKOPT",
+	BPFProgTypeTracing:               "BPF_PROG_TYPE_TRACING",
+	BPFProgTypeStructOps:             "BPF_PROG_TYPE_STRUCT_OPS",
+	BPFProgTypeExt:                   "BPF_PROG_TYPE_EXT",
+	BPFProgTypeLsm:                   "BPF_PROG_TYPE_LSM",
+	BPFProgTypeSkLookup:              "BPF_PROG_TYPE_SK_LOOKUP",
+	BPFProgTypeSyscall:               "BPF_PROG_TYPE_SYSCALL",
+}
+
+func (t BPFProgType) String() string {
+	str, ok := bpfProgTypeToString[t]
+	if !ok {
+		// BPFProgTypeUnspec must exist in bpfProgTypeToString to avoid infinite recursion.
+		return BPFProgTypeUnspec.String()
 	}
-	str = x[b]
-	if str == "" {
-		str = BPFProgTypeUnspec.String()
-	}
+
 	return str
 }
 

--- a/prog-common.go
+++ b/prog-common.go
@@ -148,6 +148,61 @@ const (
 	BPFAttachTypeTraceKprobeMulti           BPFAttachType = C.BPF_TRACE_KPROBE_MULTI
 )
 
+var bpfAttachTypeToString = map[BPFAttachType]string{
+	BPFAttachTypeCgroupInetIngress:          "BPF_CGROUP_INET_INGRESS",
+	BPFAttachTypeCgroupInetEgress:           "BPF_CGROUP_INET_EGRESS",
+	BPFAttachTypeCgroupInetSockCreate:       "BPF_CGROUP_INET_SOCK_CREATE",
+	BPFAttachTypeCgroupSockOps:              "BPF_CGROUP_SOCK_OPS",
+	BPFAttachTypeSKSKBStreamParser:          "BPF_SK_SKB_STREAM_PARSER",
+	BPFAttachTypeSKSKBStreamVerdict:         "BPF_SK_SKB_STREAM_VERDICT",
+	BPFAttachTypeCgroupDevice:               "BPF_CGROUP_DEVICE",
+	BPFAttachTypeSKMSGVerdict:               "BPF_SK_MSG_VERDICT",
+	BPFAttachTypeCgroupInet4Bind:            "BPF_CGROUP_INET4_BIND",
+	BPFAttachTypeCgroupInet6Bind:            "BPF_CGROUP_INET6_BIND",
+	BPFAttachTypeCgroupInet4Connect:         "BPF_CGROUP_INET4_CONNECT",
+	BPFAttachTypeCgroupInet6Connect:         "BPF_CGROUP_INET6_CONNECT",
+	BPFAttachTypeCgroupInet4PostBind:        "BPF_CGROUP_INET4_POST_BIND",
+	BPFAttachTypeCgroupInet6PostBind:        "BPF_CGROUP_INET6_POST_BIND",
+	BPFAttachTypeCgroupUDP4SendMsg:          "BPF_CGROUP_UDP4_SENDMSG",
+	BPFAttachTypeCgroupUDP6SendMsg:          "BPF_CGROUP_UDP6_SENDMSG",
+	BPFAttachTypeLircMode2:                  "BPF_LIRC_MODE2",
+	BPFAttachTypeFlowDissector:              "BPF_FLOW_DISSECTOR",
+	BPFAttachTypeCgroupSysctl:               "BPF_CGROUP_SYSCTL",
+	BPFAttachTypeCgroupUDP4RecvMsg:          "BPF_CGROUP_UDP4_RECVMSG",
+	BPFAttachTypeCgroupUDP6RecvMsg:          "BPF_CGROUP_UDP6_RECVMSG",
+	BPFAttachTypeCgroupGetSockOpt:           "BPF_CGROUP_GETSOCKOPT",
+	BPFAttachTypeCgroupSetSockOpt:           "BPF_CGROUP_SETSOCKOPT",
+	BPFAttachTypeTraceRawTP:                 "BPF_TRACE_RAW_TP",
+	BPFAttachTypeTraceFentry:                "BPF_TRACE_FENTRY",
+	BPFAttachTypeTraceFexit:                 "BPF_TRACE_FEXIT",
+	BPFAttachTypeModifyReturn:               "BPF_MODIFY_RETURN",
+	BPFAttachTypeLSMMac:                     "BPF_LSM_MAC",
+	BPFAttachTypeTraceIter:                  "BPF_TRACE_ITER",
+	BPFAttachTypeCgroupInet4GetPeerName:     "BPF_CGROUP_INET4_GETPEERNAME",
+	BPFAttachTypeCgroupInet6GetPeerName:     "BPF_CGROUP_INET6_GETPEERNAME",
+	BPFAttachTypeCgroupInet4GetSockName:     "BPF_CGROUP_INET4_GETSOCKNAME",
+	BPFAttachTypeCgroupInet6GetSockName:     "BPF_CGROUP_INET6_GETSOCKNAME",
+	BPFAttachTypeXDPDevMap:                  "BPF_XDP_DEVMAP",
+	BPFAttachTypeCgroupInetSockRelease:      "BPF_CGROUP_INET_SOCK_RELEASE",
+	BPFAttachTypeXDPCPUMap:                  "BPF_XDP_CPUMAP",
+	BPFAttachTypeSKLookup:                   "BPF_SK_LOOKUP",
+	BPFAttachTypeXDP:                        "BPF_XDP",
+	BPFAttachTypeSKSKBVerdict:               "BPF_SK_SKB_VERDICT",
+	BPFAttachTypeSKReusePortSelect:          "BPF_SK_REUSEPORT_SELECT",
+	BPFAttachTypeSKReusePortSelectorMigrate: "BPF_SK_REUSEPORT_SELECT_OR_MIGRATE",
+	BPFAttachTypePerfEvent:                  "BPF_PERF_EVENT",
+	BPFAttachTypeTraceKprobeMulti:           "BPF_TRACE_KPROBE_MULTI",
+}
+
+func (t BPFAttachType) String() string {
+	str, ok := bpfAttachTypeToString[t]
+	if !ok {
+		return "Unspecified"
+	}
+
+	return str
+}
+
 //
 // BPFCgroupIterOrder
 //

--- a/prog-common.go
+++ b/prog-common.go
@@ -14,38 +14,38 @@ import "C"
 type BPFProgType uint32
 
 const (
-	BPFProgTypeUnspec BPFProgType = iota
-	BPFProgTypeSocketFilter
-	BPFProgTypeKprobe
-	BPFProgTypeSchedCls
-	BPFProgTypeSchedAct
-	BPFProgTypeTracepoint
-	BPFProgTypeXdp
-	BPFProgTypePerfEvent
-	BPFProgTypeCgroupSkb
-	BPFProgTypeCgroupSock
-	BPFProgTypeLwtIn
-	BPFProgTypeLwtOut
-	BPFProgTypeLwtXmit
-	BPFProgTypeSockOps
-	BPFProgTypeSkSkb
-	BPFProgTypeCgroupDevice
-	BPFProgTypeSkMsg
-	BPFProgTypeRawTracepoint
-	BPFProgTypeCgroupSockAddr
-	BPFProgTypeLwtSeg6Local
-	BPFProgTypeLircMode2
-	BPFProgTypeSkReuseport
-	BPFProgTypeFlowDissector
-	BPFProgTypeCgroupSysctl
-	BPFProgTypeRawTracepointWritable
-	BPFProgTypeCgroupSockopt
-	BPFProgTypeTracing
-	BPFProgTypeStructOps
-	BPFProgTypeExt
-	BPFProgTypeLsm
-	BPFProgTypeSkLookup
-	BPFProgTypeSyscall
+	BPFProgTypeUnspec                BPFProgType = C.BPF_PROG_TYPE_UNSPEC
+	BPFProgTypeSocketFilter          BPFProgType = C.BPF_PROG_TYPE_SOCKET_FILTER
+	BPFProgTypeKprobe                BPFProgType = C.BPF_PROG_TYPE_KPROBE
+	BPFProgTypeSchedCls              BPFProgType = C.BPF_PROG_TYPE_SCHED_CLS
+	BPFProgTypeSchedAct              BPFProgType = C.BPF_PROG_TYPE_SCHED_ACT
+	BPFProgTypeTracepoint            BPFProgType = C.BPF_PROG_TYPE_TRACEPOINT
+	BPFProgTypeXdp                   BPFProgType = C.BPF_PROG_TYPE_XDP
+	BPFProgTypePerfEvent             BPFProgType = C.BPF_PROG_TYPE_PERF_EVENT
+	BPFProgTypeCgroupSkb             BPFProgType = C.BPF_PROG_TYPE_CGROUP_SKB
+	BPFProgTypeCgroupSock            BPFProgType = C.BPF_PROG_TYPE_CGROUP_SOCK
+	BPFProgTypeLwtIn                 BPFProgType = C.BPF_PROG_TYPE_LWT_IN
+	BPFProgTypeLwtOut                BPFProgType = C.BPF_PROG_TYPE_LWT_OUT
+	BPFProgTypeLwtXmit               BPFProgType = C.BPF_PROG_TYPE_LWT_XMIT
+	BPFProgTypeSockOps               BPFProgType = C.BPF_PROG_TYPE_SOCK_OPS
+	BPFProgTypeSkSkb                 BPFProgType = C.BPF_PROG_TYPE_SK_SKB
+	BPFProgTypeCgroupDevice          BPFProgType = C.BPF_PROG_TYPE_CGROUP_DEVICE
+	BPFProgTypeSkMsg                 BPFProgType = C.BPF_PROG_TYPE_SK_MSG
+	BPFProgTypeRawTracepoint         BPFProgType = C.BPF_PROG_TYPE_RAW_TRACEPOINT
+	BPFProgTypeCgroupSockAddr        BPFProgType = C.BPF_PROG_TYPE_CGROUP_SOCK_ADDR
+	BPFProgTypeLwtSeg6Local          BPFProgType = C.BPF_PROG_TYPE_LWT_SEG6LOCAL
+	BPFProgTypeLircMode2             BPFProgType = C.BPF_PROG_TYPE_LIRC_MODE2
+	BPFProgTypeSkReuseport           BPFProgType = C.BPF_PROG_TYPE_SK_REUSEPORT
+	BPFProgTypeFlowDissector         BPFProgType = C.BPF_PROG_TYPE_FLOW_DISSECTOR
+	BPFProgTypeCgroupSysctl          BPFProgType = C.BPF_PROG_TYPE_CGROUP_SYSCTL
+	BPFProgTypeRawTracepointWritable BPFProgType = C.BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
+	BPFProgTypeCgroupSockopt         BPFProgType = C.BPF_PROG_TYPE_CGROUP_SOCKOPT
+	BPFProgTypeTracing               BPFProgType = C.BPF_PROG_TYPE_TRACING
+	BPFProgTypeStructOps             BPFProgType = C.BPF_PROG_TYPE_STRUCT_OPS
+	BPFProgTypeExt                   BPFProgType = C.BPF_PROG_TYPE_EXT
+	BPFProgTypeLsm                   BPFProgType = C.BPF_PROG_TYPE_LSM
+	BPFProgTypeSkLookup              BPFProgType = C.BPF_PROG_TYPE_SK_LOOKUP
+	BPFProgTypeSyscall               BPFProgType = C.BPF_PROG_TYPE_SYSCALL
 )
 
 // Deprecated: Convert type directly instead.
@@ -103,49 +103,49 @@ func (t BPFProgType) String() string {
 type BPFAttachType uint32
 
 const (
-	BPFAttachTypeCgroupInetIngress BPFAttachType = iota
-	BPFAttachTypeCgroupInetEgress
-	BPFAttachTypeCgroupInetSockCreate
-	BPFAttachTypeCgroupSockOps
-	BPFAttachTypeSKSKBStreamParser
-	BPFAttachTypeSKSKBStreamVerdict
-	BPFAttachTypeCgroupDevice
-	BPFAttachTypeSKMSGVerdict
-	BPFAttachTypeCgroupInet4Bind
-	BPFAttachTypeCgroupInet6Bind
-	BPFAttachTypeCgroupInet4Connect
-	BPFAttachTypeCgroupInet6Connect
-	BPFAttachTypeCgroupInet4PostBind
-	BPFAttachTypeCgroupInet6PostBind
-	BPFAttachTypeCgroupUDP4SendMsg
-	BPFAttachTypeCgroupUDP6SendMsg
-	BPFAttachTypeLircMode2
-	BPFAttachTypeFlowDissector
-	BPFAttachTypeCgroupSysctl
-	BPFAttachTypeCgroupUDP4RecvMsg
-	BPFAttachTypeCgroupUDP6RecvMsg
-	BPFAttachTypeCgroupGetSockOpt
-	BPFAttachTypeCgroupSetSockOpt
-	BPFAttachTypeTraceRawTP
-	BPFAttachTypeTraceFentry
-	BPFAttachTypeTraceFexit
-	BPFAttachTypeModifyReturn
-	BPFAttachTypeLSMMac
-	BPFAttachTypeTraceIter
-	BPFAttachTypeCgroupInet4GetPeerName
-	BPFAttachTypeCgroupInet6GetPeerName
-	BPFAttachTypeCgroupInet4GetSockName
-	BPFAttachTypeCgroupInet6GetSockName
-	BPFAttachTypeXDPDevMap
-	BPFAttachTypeCgroupInetSockRelease
-	BPFAttachTypeXDPCPUMap
-	BPFAttachTypeSKLookup
-	BPFAttachTypeXDP
-	BPFAttachTypeSKSKBVerdict
-	BPFAttachTypeSKReusePortSelect
-	BPFAttachTypeSKReusePortSelectorMigrate
-	BPFAttachTypePerfEvent
-	BPFAttachTypeTraceKprobeMulti
+	BPFAttachTypeCgroupInetIngress          BPFAttachType = C.BPF_CGROUP_INET_INGRESS
+	BPFAttachTypeCgroupInetEgress           BPFAttachType = C.BPF_CGROUP_INET_EGRESS
+	BPFAttachTypeCgroupInetSockCreate       BPFAttachType = C.BPF_CGROUP_INET_SOCK_CREATE
+	BPFAttachTypeCgroupSockOps              BPFAttachType = C.BPF_CGROUP_SOCK_OPS
+	BPFAttachTypeSKSKBStreamParser          BPFAttachType = C.BPF_SK_SKB_STREAM_PARSER
+	BPFAttachTypeSKSKBStreamVerdict         BPFAttachType = C.BPF_SK_SKB_STREAM_VERDICT
+	BPFAttachTypeCgroupDevice               BPFAttachType = C.BPF_CGROUP_DEVICE
+	BPFAttachTypeSKMSGVerdict               BPFAttachType = C.BPF_SK_MSG_VERDICT
+	BPFAttachTypeCgroupInet4Bind            BPFAttachType = C.BPF_CGROUP_INET4_BIND
+	BPFAttachTypeCgroupInet6Bind            BPFAttachType = C.BPF_CGROUP_INET6_BIND
+	BPFAttachTypeCgroupInet4Connect         BPFAttachType = C.BPF_CGROUP_INET4_CONNECT
+	BPFAttachTypeCgroupInet6Connect         BPFAttachType = C.BPF_CGROUP_INET6_CONNECT
+	BPFAttachTypeCgroupInet4PostBind        BPFAttachType = C.BPF_CGROUP_INET4_POST_BIND
+	BPFAttachTypeCgroupInet6PostBind        BPFAttachType = C.BPF_CGROUP_INET6_POST_BIND
+	BPFAttachTypeCgroupUDP4SendMsg          BPFAttachType = C.BPF_CGROUP_UDP4_SENDMSG
+	BPFAttachTypeCgroupUDP6SendMsg          BPFAttachType = C.BPF_CGROUP_UDP6_SENDMSG
+	BPFAttachTypeLircMode2                  BPFAttachType = C.BPF_LIRC_MODE2
+	BPFAttachTypeFlowDissector              BPFAttachType = C.BPF_FLOW_DISSECTOR
+	BPFAttachTypeCgroupSysctl               BPFAttachType = C.BPF_CGROUP_SYSCTL
+	BPFAttachTypeCgroupUDP4RecvMsg          BPFAttachType = C.BPF_CGROUP_UDP4_RECVMSG
+	BPFAttachTypeCgroupUDP6RecvMsg          BPFAttachType = C.BPF_CGROUP_UDP6_RECVMSG
+	BPFAttachTypeCgroupGetSockOpt           BPFAttachType = C.BPF_CGROUP_GETSOCKOPT
+	BPFAttachTypeCgroupSetSockOpt           BPFAttachType = C.BPF_CGROUP_SETSOCKOPT
+	BPFAttachTypeTraceRawTP                 BPFAttachType = C.BPF_TRACE_RAW_TP
+	BPFAttachTypeTraceFentry                BPFAttachType = C.BPF_TRACE_FENTRY
+	BPFAttachTypeTraceFexit                 BPFAttachType = C.BPF_TRACE_FEXIT
+	BPFAttachTypeModifyReturn               BPFAttachType = C.BPF_MODIFY_RETURN
+	BPFAttachTypeLSMMac                     BPFAttachType = C.BPF_LSM_MAC
+	BPFAttachTypeTraceIter                  BPFAttachType = C.BPF_TRACE_ITER
+	BPFAttachTypeCgroupInet4GetPeerName     BPFAttachType = C.BPF_CGROUP_INET4_GETPEERNAME
+	BPFAttachTypeCgroupInet6GetPeerName     BPFAttachType = C.BPF_CGROUP_INET6_GETPEERNAME
+	BPFAttachTypeCgroupInet4GetSockName     BPFAttachType = C.BPF_CGROUP_INET4_GETSOCKNAME
+	BPFAttachTypeCgroupInet6GetSockName     BPFAttachType = C.BPF_CGROUP_INET6_GETSOCKNAME
+	BPFAttachTypeXDPDevMap                  BPFAttachType = C.BPF_XDP_DEVMAP
+	BPFAttachTypeCgroupInetSockRelease      BPFAttachType = C.BPF_CGROUP_INET_SOCK_RELEASE
+	BPFAttachTypeXDPCPUMap                  BPFAttachType = C.BPF_XDP_CPUMAP
+	BPFAttachTypeSKLookup                   BPFAttachType = C.BPF_SK_LOOKUP
+	BPFAttachTypeXDP                        BPFAttachType = C.BPF_XDP
+	BPFAttachTypeSKSKBVerdict               BPFAttachType = C.BPF_SK_SKB_VERDICT
+	BPFAttachTypeSKReusePortSelect          BPFAttachType = C.BPF_SK_REUSEPORT_SELECT
+	BPFAttachTypeSKReusePortSelectorMigrate BPFAttachType = C.BPF_SK_REUSEPORT_SELECT_OR_MIGRATE
+	BPFAttachTypePerfEvent                  BPFAttachType = C.BPF_PERF_EVENT
+	BPFAttachTypeTraceKprobeMulti           BPFAttachType = C.BPF_TRACE_KPROBE_MULTI
 )
 
 //


### PR DESCRIPTION
Context: #218

commit 9f3d56d9cefdbe4051b79bb083d51f096d005a7b (HEAD -> enum-string-api)

    feat: introduce enum string api
    
    This adds the Name() method to MapType, BPFAttachType and BPFProgType,
    which relies on libbpf_bpf_map_type_str(), libbpf_bpf_attach_type_str()
    and libbpf_bpf_prog_type_str() respectively.

commit eb4b6131fd77f893482489c5c1b8be95846b6d2c

    chore(prog): add BPFAttachType string API

commit 424283a7736c80562f92115c720150293e35be44

    chore: assign constants with C enum values
    
    This avoids wrong values if changes happen.

commit cd3df8da3ae4000e8d9d25272254a877db4acdd4

    chore(prog): instantiate bpfProgTypeToString
    
    This avoids the need to instantiate the map in every call to
    BPFProgType.String().

commit bc215c44c1d91f808cc90938c3ce3b6686cdf2b8

    chore(prog): deprecate BPFProgType.Value()

commit 5e4fbbba4f5893012077871bfa7646af031cf90d

    fix(map): return unspecified for unknown type