### PR TITLE
Map batch API

### DIFF
--- a/selftest/map-batch/main.bpf.c
+++ b/selftest/map-batch/main.bpf.c
@@ -8,7 +8,7 @@ struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, u32);
     __type(value, u32);
-    __uint(max_entries, 1 << 24);
+    __uint(max_entries, 4);
 } tester SEC(".maps");
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-batch/main.go
+++ b/selftest/map-batch/main.go
@@ -3,11 +3,12 @@ package main
 import "C"
 
 import (
-	"os"
+	"errors"
+	"log"
+	"syscall"
 	"unsafe"
 
 	"encoding/binary"
-	"fmt"
 
 	bpf "github.com/aquasecurity/libbpfgo"
 )
@@ -15,8 +16,7 @@ import (
 func main() {
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
+		log.Fatalf("Failed to load BPF module: %v", err)
 	}
 	defer bpfModule.Close()
 
@@ -24,134 +24,239 @@ func main() {
 
 	testerMap, err := bpfModule.GetMap("tester")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
+		log.Fatalf("Failed to get map: %v", err)
 	}
 
-	keys := []uint32{1, 2, 3, 4, 5, 6, 8}
-	values := []uint32{2, 3, 4, 5, 6, 7, 9}
+	//
+	// UpdateBatch
+	//
 
 	// Test batch update.
-	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.UpdateBatch failed: %v", err)
-		os.Exit(-1)
+	keys := []uint32{1, 2, 3, 4}
+	values := []uint32{2, 3, 4, 5}
+
+	count, err := testerMap.UpdateBatch(
+		unsafe.Pointer(&keys[0]),
+		unsafe.Pointer(&values[0]),
+		uint32(len(keys)),
+	)
+	if err != nil {
+		log.Fatal(err)
 	}
+	if count != uint32(len(keys)) {
+		log.Fatalf("Failed to batch update all elements: %d/%d", count, len(keys))
+	}
+
 	val, err := testerMap.GetValue(unsafe.Pointer(&keys[0]))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.GetValue failed: %v", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
-	if binary.LittleEndian.Uint32(val) != values[0] {
-		fmt.Fprintf(os.Stderr, "testerMap.GetValue returned %v, expected %v", val, values[0])
-		os.Exit(-1)
+	if endian().Uint32(val) != values[0] {
+		log.Fatalf("testerMap.GetValue returned %v, expected %v", val, values[0])
 	}
+
+	// Test batch update.
+	// Trying to update more entries than max_entries.
+	keysGreater := []uint32{1, 2, 3, 4, 100} // 100 won't be added, since max_entries is 4.
+	valuesGreater := []uint32{2, 3, 4, 5, 100}
+
+	count, err = testerMap.UpdateBatch(
+		unsafe.Pointer(&keysGreater[0]),
+		unsafe.Pointer(&valuesGreater[0]),
+		uint32(len(keysGreater)),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if count == uint32(len(keysGreater)) {
+		log.Fatalf("count %d should be less than len(keysGreater) %d", count, len(keysGreater))
+	}
+
+	//
+	// GetValueBatch
+	//
 
 	// Test batch lookup in steps.
 	batchKeys := make([]uint32, 3)
-	nextKey := uint32(0)
-	prevKey := unsafe.Pointer(nil)
-	step := len(batchKeys)
+	startKeyPtr := unsafe.Pointer(nil)
+	nextKey := uint64(0)
+	stepSize := len(batchKeys)
 	for i := 0; i < 2; i++ {
-		if i > 0 {
-			// We're on step 2, so test the batch lookup by specifying the
-			// key to start from.
-			prevKey = unsafe.Pointer(&nextKey)
-		}
-		vals, err := testerMap.GetValueBatch(unsafe.Pointer(&batchKeys[0]), prevKey, unsafe.Pointer(&nextKey), uint32(step))
+		vals, _, err := testerMap.GetValueBatch(
+			unsafe.Pointer(&batchKeys[0]),
+			startKeyPtr,
+			unsafe.Pointer(&nextKey),
+			uint32(stepSize),
+		)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "step %d testerMap.LookupBatch failed: %v", i, err)
-			os.Exit(-1)
+			log.Fatalf("Failed to batch lookup: %v", err)
 		}
+
+		startKeyPtr = unsafe.Pointer(&nextKey)
+
 		for i, val := range vals {
-			actual := binary.LittleEndian.Uint32(val)
+			actual := endian().Uint32(val)
 			expected := batchKeys[i] + 1
 			if actual != expected {
-				fmt.Fprintf(os.Stderr, "testerMap.LookupBatch returned %v, expected %v", actual, expected)
-				os.Exit(-1)
+				log.Fatalf("testerMap.GetValueBatch returned %v, expected %v", actual, expected)
 			}
 		}
 	}
 
-	// Test batch get value with more elements than we have.
-	_, err = testerMap.GetValueBatch(unsafe.Pointer(&batchKeys[0]), prevKey, unsafe.Pointer(&nextKey), uint32(len(batchKeys))+100)
+	// Test batch lookup an unavailable key between available keys.
+	notAllAvailableKeys := []uint32{10, 1, 2, 3, 4} // 10 is not in the map.
+	expectedCount := uint32(len(notAllAvailableKeys) - 1)
+	startKeyPtr = unsafe.Pointer(nil)
+	nextKey = uint64(0)
+	_, count, err = testerMap.GetValueBatch(
+		unsafe.Pointer(&notAllAvailableKeys[0]),
+		startKeyPtr,
+		unsafe.Pointer(&nextKey),
+		uint32(len(notAllAvailableKeys)),
+	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.GetValueBatch failed: %v", err)
-		os.Exit(-1)
+		log.Fatal(err)
+	}
+	if count != expectedCount {
+		log.Fatalf("Failed to partial batch lookup elements: %d/%d", count, len(keys))
 	}
 
-	// Test batch lookup and delete.
-	deleteKeys := make([]uint32, 2)
-	nextKey = uint32(0)
-	requestedCount := len(deleteKeys)
-
-	vals, err := testerMap.GetValueAndDeleteBatch(unsafe.Pointer(&deleteKeys[0]), nil, unsafe.Pointer(&nextKey), uint32(requestedCount))
+	// Test batch lookup passing a count that is greater than the number of
+	// available elements.
+	greaterCount := len(batchKeys) + 10
+	startKeyPtr = unsafe.Pointer(nil)
+	nextKey = uint64(0)
+	_, count, err = testerMap.GetValueBatch(
+		unsafe.Pointer(&batchKeys[0]),
+		startKeyPtr,
+		unsafe.Pointer(&nextKey),
+		uint32(greaterCount),
+	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.LookupBatch failed: %v", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
-	processedCount := len(vals)
-	if requestedCount != processedCount {
-		fmt.Fprintf(os.Stderr, "testerMap.LookupBatch failed: %d!=%d", requestedCount, processedCount)
-		os.Exit(-1)
-	}
-	for i, val := range vals {
-		actual := binary.LittleEndian.Uint32(val)
-		expected := deleteKeys[i] + 1
-		if actual != expected {
-			fmt.Fprintf(os.Stderr, "testerMap.LookupBatch returned %v, expected %v", actual, expected)
-			os.Exit(-1)
+
+	//
+	// GetValueAndDeleteBatch
+	//
+
+	// Test batch lookup and delete in steps.
+	totalKeysToDelete := uint32(3)
+	stepSize = 1
+	step := 0
+	for totalKeysToDelete > 0 && step < 10 {
+		if totalKeysToDelete < uint32(stepSize) {
+			stepSize = int(totalKeysToDelete)
+		}
+		deleteKeys := make([]uint32, stepSize)
+		startKeyPtr = unsafe.Pointer(nil)
+		nextKey = uint64(0)
+		vals, count, err := testerMap.GetValueAndDeleteBatch(
+			unsafe.Pointer(&deleteKeys[0]),
+			startKeyPtr,
+			unsafe.Pointer(&nextKey),
+			uint32(stepSize),
+		)
+		if err != nil {
+			if errors.Is(err, syscall.ENOSPC) {
+				// Reference:
+				// https://elixir.bootlin.com/linux/v6.4.13/source/tools/testing/selftests/bpf/map_tests/htab_map_batch_ops.c#L158
+				log.Printf("totalKeysToDelete: %d, step: %d, stepSize: %d", totalKeysToDelete, step, stepSize)
+				if uint32(stepSize) < totalKeysToDelete {
+					stepSize++
+				}
+
+				step++
+				continue
+			}
+			log.Fatal(err)
+		}
+		log.Printf("testerMap.GetValueAndDeleteBatch deleted element(s): %d", count)
+		totalKeysToDelete -= count
+
+		for i, val := range vals {
+			actual := endian().Uint32(val)
+			expected := deleteKeys[i] + 1
+			if actual != expected {
+				log.Fatalf("testerMap.GetValueAndDeleteBatch returned %v, expected %v", actual, expected)
+			}
 		}
 	}
-
-	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.UpdateBatch failed: %v", err)
-		os.Exit(-1)
+	if totalKeysToDelete != 0 {
+		// Don't fail, since this should not always work.
+		log.Printf("Due to ENOSPC, not all keys were deleted, remaining: %d", totalKeysToDelete)
 	}
+
+	//
+	// DeleteKeyBatch
+	//
+
+	// Re-add deleted entries.
+	_, err = testerMap.UpdateBatch(
+		unsafe.Pointer(&keys[0]),
+		unsafe.Pointer(&values[0]),
+		uint32(len(keys)),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// map is full again.
 
 	// Test batch delete.
 	// Trying to delete more keys than we have.
-	err = testerMap.DeleteKeyBatch(unsafe.Pointer(&keys[0]), uint32(len(keys)+100))
+	count, err = testerMap.DeleteKeyBatch(
+		unsafe.Pointer(&keys[0]),
+		uint32(len(keys)+10),
+	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.DeleteKeyBatch was expected to not fail")
-		os.Exit(-1)
+		log.Fatal(err)
+	}
+	if count != uint32(len(keys)) {
+		log.Fatalf("testerMap.DeleteKeyBatch failed: count=%d", count)
 	}
 
 	// Ensure value is no longer there.
-	_, err = testerMap.GetValue(unsafe.Pointer(&keys[0]))
-	if err == nil {
-		fmt.Fprintf(os.Stderr, "testerMap.GetValue was expected to fail, but succeeded")
-		os.Exit(-1)
+	v, _ := testerMap.GetValue(unsafe.Pointer(&keys[0]))
+	if len(v) != 0 {
+		log.Fatalf("testerMap.GetValue was expected to fail, but succeeded")
 	}
 
+	// map is empty again.
+
 	// Re-add deleted entries.
-	if err := testerMap.UpdateBatch(unsafe.Pointer(&keys[0]), unsafe.Pointer(&values[0]), uint32(len(keys))); err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.UpdateBatch failed: %v", err)
-		os.Exit(-1)
+	_, err = testerMap.UpdateBatch(
+		unsafe.Pointer(&keys[0]),
+		unsafe.Pointer(&values[0]),
+		uint32(len(keys)),
+	)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// Test batch delete.
 	// Trying to delete fewer or equal keys than we have.
-	err = testerMap.DeleteKeyBatch(unsafe.Pointer(&keys[0]), uint32(len(keys)-1))
+	fewer := 3
+	count, err = testerMap.DeleteKeyBatch(
+		unsafe.Pointer(&keys[0]),
+		uint32(fewer),
+	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.DeleteKeyBatch was expected to not fail")
-		os.Exit(-1)
+		log.Fatal(err)
+	}
+	if count != uint32(fewer) {
+		log.Fatalf("testerMap.DeleteKeyBatch failed: count=%d", count)
+	}
+}
+
+func endian() binary.ByteOrder {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		return binary.LittleEndian
 	}
 
-	// Test batch lookup and delete when requesting more elements than are in the map.
-	deleteKeys = make([]uint32, 3)
-	nextKey = uint32(0)
-	requestedCount = 5
-
-	vals, err = testerMap.GetValueAndDeleteBatch(unsafe.Pointer(&deleteKeys[0]), nil, unsafe.Pointer(&nextKey), uint32(requestedCount))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "testerMap.LookupBatch failed: %v", err)
-		os.Exit(-1)
-	}
-	processedCount = len(vals)
-
-	// We removed all but one element in the test case before.
-	if processedCount != 1 {
-		fmt.Fprintf(os.Stderr, "testerMap.LookupBatch failed: processedCount=%d", processedCount)
-		os.Exit(-1)
-	}
+	return binary.BigEndian
 }


### PR DESCRIPTION
Close: https://github.com/aquasecurity/libbpfgo/issues/162

commit 9382e51652377376ef9459901c49abbcf39758b3 (HEAD -> map-batch, origin/map-batch)

    fix(map)!: fix map batch methods
    
    This breaks the API, returning a count of the number of elements
    processed for each batch method.
    
    It also fixes the check against ENOENT and E2BIG.
    
    The selftest has been updated to reflect the new API.