### PR TITLE
Simplify GetMapsIDsByName

### DIFF
--- a/map-low.go
+++ b/map-low.go
@@ -137,14 +137,14 @@ func GetMapNextID(startId uint32) (uint32, error) {
 //	        // Update 'startId' to the last processed map ID to continue the search.
 //	    }
 //	}
-func GetMapsIDsByName(name string, startId uint32) ([]uint32, error) {
+func GetMapsIDsByName(name string, startId *uint32) ([]uint32, error) {
 	var (
 		bpfMapsIds []uint32
 		err        error
 	)
 
 	for {
-		startId, err = GetMapNextID(startId)
+		*startId, err = GetMapNextID(*startId)
 		if err != nil {
 			if errors.Is(err, syscall.ENOENT) {
 				return bpfMapsIds, nil
@@ -153,7 +153,7 @@ func GetMapsIDsByName(name string, startId uint32) ([]uint32, error) {
 			return bpfMapsIds, err
 		}
 
-		bpfMapLow, err := GetMapByID(startId)
+		bpfMapLow, err := GetMapByID(*startId)
 		if err != nil {
 			return bpfMapsIds, err
 		}

--- a/map-low.go
+++ b/map-low.go
@@ -105,11 +105,10 @@ func GetMapByID(id uint32) (*BPFMapLow, error) {
 func GetMapsIDsByName(name string) ([]uint32, error) {
 	bpfMapsIds := []uint32{}
 
-	startId := C.uint(0)
-	nextId := C.uint(0)
+	id := C.uint(0)
 
 	for {
-		retC := C.bpf_map_get_next_id(startId, &nextId)
+		retC := C.bpf_map_get_next_id(id, &id)
 		errno := syscall.Errno(-retC)
 		if retC < 0 {
 			if errno == syscall.ENOENT {
@@ -119,9 +118,7 @@ func GetMapsIDsByName(name string) ([]uint32, error) {
 			return bpfMapsIds, fmt.Errorf("failed to get next map id: %w", errno)
 		}
 
-		startId = nextId + 1
-
-		bpfMapLow, err := GetMapByID(uint32(nextId))
+		bpfMapLow, err := GetMapByID(uint32(id))
 		if err != nil {
 			return bpfMapsIds, err
 		}

--- a/selftest/map-getmapsbyname/main.bpf.c
+++ b/selftest/map-getmapsbyname/main.bpf.c
@@ -11,12 +11,10 @@ struct {
     __uint(value_size, sizeof(u32));
 } test_name SEC(".maps");
 
-// Define a struct to hold path and method
 struct test_struct {
     char value[10];
 };
 
-// Define the eBPF map to store the path-method pairs
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 1);

--- a/selftest/map-getmapsbyname/main.bpf.c
+++ b/selftest/map-getmapsbyname/main.bpf.c
@@ -11,4 +11,17 @@ struct {
     __uint(value_size, sizeof(u32));
 } test_name SEC(".maps");
 
+// Define a struct to hold path and method
+struct test_struct {
+    char value[10];
+};
+
+// Define the eBPF map to store the path-method pairs
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1);
+    __type(key, int);
+    __type(value, struct test_struct);
+} test_hash_name SEC(".maps");
+
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/selftest/map-getmapsbyname/main.go
+++ b/selftest/map-getmapsbyname/main.go
@@ -13,6 +13,7 @@ import (
 const (
 	BPFMapNameToNotFind = "not_found"
 	// The following properties are used to identify the map
+	BPFHashMapNameToFind   = "test_hash_name"
 	BPFMapNameToFind       = "test_name"
 	BPFMapTypeToFind       = bpf.MapTypeArray
 	BPFMapMaxEntriesToFind = 1
@@ -32,6 +33,11 @@ func main() {
 	notFoundMapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToNotFind)
 	if len(notFoundMapsIDs) != 0 {
 		log.Fatalf("the %s map should not be found, but it was found with ids: %v", BPFMapNameToNotFind, notFoundMapsIDs)
+	}
+
+	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind)
+	if len(bpfHashMapsIDs) == 0 {
+		log.Fatalf("the %s map should be found", BPFHashMapNameToFind)
 	}
 
 	mapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToFind)

--- a/selftest/map-getmapsbyname/main.go
+++ b/selftest/map-getmapsbyname/main.go
@@ -30,12 +30,12 @@ func main() {
 
 	bpfModule.BPFLoadObject()
 
-	notFoundMapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToNotFind)
+	notFoundMapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToNotFind, 0)
 	if len(notFoundMapsIDs) != 0 {
 		log.Fatalf("the %s map should not be found, but it was found with ids: %v", BPFMapNameToNotFind, notFoundMapsIDs)
 	}
 
-	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind)
+	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("the %s map should be found", BPFHashMapNameToFind)
 	}
 
-	mapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToFind)
+	mapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToFind, 0)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/selftest/map-getmapsbyname/main.go
+++ b/selftest/map-getmapsbyname/main.go
@@ -30,12 +30,14 @@ func main() {
 
 	bpfModule.BPFLoadObject()
 
-	notFoundMapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToNotFind, 0)
+	startId := uint32(0)
+	notFoundMapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToNotFind, &startId)
 	if len(notFoundMapsIDs) != 0 {
 		log.Fatalf("the %s map should not be found, but it was found with ids: %v", BPFMapNameToNotFind, notFoundMapsIDs)
 	}
 
-	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind, 0)
+	startId = 0
+	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind, &startId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,7 +45,8 @@ func main() {
 		log.Fatalf("the %s map should be found", BPFHashMapNameToFind)
 	}
 
-	mapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToFind, 0)
+	startId = 0
+	mapsIDs, err := bpf.GetMapsIDsByName(BPFMapNameToFind, &startId)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/selftest/map-getmapsbyname/main.go
+++ b/selftest/map-getmapsbyname/main.go
@@ -36,6 +36,9 @@ func main() {
 	}
 
 	bpfHashMapsIDs, err := bpf.GetMapsIDsByName(BPFHashMapNameToFind)
+	if err != nil {
+		log.Fatal(err)
+	}
 	if len(bpfHashMapsIDs) == 0 {
 		log.Fatalf("the %s map should be found", BPFHashMapNameToFind)
 	}


### PR DESCRIPTION
The `id` is incremented by `C.bpf_map_get_next_id` so no need to define the `startId` and `nextId`. I encounter some weird behavior in my project when I was using map with a BPF_MAP_TYPE_HASH type.