### PR TITLE
fix: pin revive to e33fb87

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,7 +31,7 @@ jobs:
       #   shell: bash
       - name: Install revive
         run: |
-          go install github.com/mgechev/revive@latest
+          go install github.com/mgechev/revive@e33fb87
           sudo cp $HOME/go/bin/revive /usr/bin/
         shell: bash
       # - name: Install goimports-reviser


### PR DESCRIPTION
revive v1.3.5 wrongly includes a replace directive which breaks the go install command.

This commit pins revive to e33fb87 that is the fix for this issue.