### PR TITLE
feature: Add AttachProgs/DetachProgs api for bpf object

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -111,6 +111,10 @@ func (p *BPFProg) SetAutoload(autoload bool) error {
 	return nil
 }
 
+func (p *BPFProg) Autoload() bool {
+	return bool(C.bpf_program__autoload(p.prog))
+}
+
 func (p *BPFProg) SetAutoattach(autoload bool) {
 	C.bpf_program__set_autoattach(p.prog, C.bool(autoload))
 }

--- a/selftest/module-attach-detach/Makefile
+++ b/selftest/module-attach-detach/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/selftest/module-attach-detach/go.mod
+++ b/selftest/module-attach-detach/go.mod
@@ -1,0 +1,14 @@
+module github.com/aquasecurity/libbpfgo/selftest/module-attach-detach
+
+go 1.18
+
+require (
+	github.com/aquasecurity/libbpfgo v0.4.7-libbpf-1.2.0-b2e29a1
+	github.com/aquasecurity/libbpfgo/helpers v0.4.5
+)
+
+require golang.org/x/sys v0.7.0 // indirect
+
+replace github.com/aquasecurity/libbpfgo => ../../
+
+replace github.com/aquasecurity/libbpfgo/helpers => ../../helpers

--- a/selftest/module-attach-detach/go.sum
+++ b/selftest/module-attach-detach/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/selftest/module-attach-detach/main.bpf.c
+++ b/selftest/module-attach-detach/main.bpf.c
@@ -1,0 +1,24 @@
+//+build ignore
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#ifdef __TARGET_ARCH_amd64
+SEC("fentry/__x64_sys_mmap")
+#elif defined(__TARGET_ARCH_arm64)
+SEC("fentry/__arm64_sys_mmap")
+#endif
+int sys_mmap(struct pt_regs *ctx)
+{
+    return 0;
+}
+
+SEC("kprobe/do_sys_open")
+int kprobe__sys_open(struct pt_regs *ctx)
+{
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/selftest/module-attach-detach/main.go
+++ b/selftest/module-attach-detach/main.go
@@ -1,0 +1,40 @@
+package main
+
+import "C"
+
+import (
+	"os"
+
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+)
+
+func main() {
+	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	err = bpfModule.BPFLoadObject()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
+	// attach all programs
+	err = bpfModule.AttachPrograms()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("attach programs failed: %s", err))
+		os.Exit(-1)
+	}
+
+	// detach all programs
+	err = bpfModule.DetachPrograms()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("detach programs failed: %s", err))
+		os.Exit(-1)
+	}
+}

--- a/selftest/module-attach-detach/run.sh
+++ b/selftest/module-attach-detach/run.sh
@@ -1,0 +1,1 @@
+../common/run.sh

--- a/selftest/probe-features/main.go
+++ b/selftest/probe-features/main.go
@@ -44,6 +44,15 @@ func main() {
 		}
 	}
 
+	// Test auto load result
+	autoLoadOrig := kprobeProg.Autoload()
+	kprobeProg.SetAutoload((!autoLoadOrig))
+	if kprobeProg.Autoload() == autoLoadOrig {
+		fmt.Println(os.Stderr, "auto load result wrong")
+		os.Exit(-1)
+	}
+	kprobeProg.SetAutoload((autoLoadOrig))
+
 	err = bpfModule.BPFLoadObject()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Add AttachProgs/DetachProgs api for bpf object like api in libbpf: bpf_object__attach_skeleton/bpf_object__detach_skeleton. So we don't need to specify the program name to attach one by one.