### PR TITLE
Add new methods to Map API

### DIFF
--- a/map-common.go
+++ b/map-common.go
@@ -175,13 +175,9 @@ func GetMapInfoByFD(fd int) (*BPFMapInfo, error) {
 	}, nil
 }
 
-//
-// Map misc internal
-//
-
-// calcMapValueSize calculates the size of the value for a map.
+// CalcMapValueSize calculates the size of the value for a map.
 // For per-CPU maps, it is calculated based on the number of possible CPUs.
-func calcMapValueSize(valueSize int, mapType MapType) (int, error) {
+func CalcMapValueSize(valueSize int, mapType MapType) (int, error) {
 	if valueSize <= 0 {
 		return 0, fmt.Errorf("value size must be greater than 0")
 	}

--- a/map-low.go
+++ b/map-low.go
@@ -260,7 +260,7 @@ func (m *BPFMapLow) GetValue(key unsafe.Pointer) ([]byte, error) {
 }
 
 func (m *BPFMapLow) GetValueFlags(key unsafe.Pointer, flags MapFlag) ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -314,7 +314,7 @@ func (m *BPFMapLow) LookupAndDeleteElemFlags(
 }
 
 func (m *BPFMapLow) GetValueAndDeleteKey(key unsafe.Pointer) ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -332,7 +332,7 @@ func (m *BPFMapLow) GetValueAndDeleteKey(key unsafe.Pointer) ([]byte, error) {
 }
 
 func (m *BPFMapLow) GetValueAndDeleteKeyFlags(key unsafe.Pointer, flags MapFlag) ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -397,7 +397,7 @@ func (m *BPFMapLow) GetNextKey(key unsafe.Pointer, nextKey unsafe.Pointer) error
 // GetValueBatch gets the values with the given keys from the map.
 // It returns the values and the number of read elements.
 func (m *BPFMapLow) GetValueBatch(keys, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, uint32, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, 0, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -444,7 +444,7 @@ func (m *BPFMapLow) GetValueBatch(keys, startKey, nextKey unsafe.Pointer, count 
 // deletes them.
 // It returns the values and the number of deleted elements.
 func (m *BPFMapLow) GetValueAndDeleteBatch(keys, startKey, nextKey unsafe.Pointer, count uint32) ([][]byte, uint32, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, 0, fmt.Errorf("map %s %w", m.Name(), err)
 	}

--- a/map.go
+++ b/map.go
@@ -215,7 +215,7 @@ func (m *BPFMap) MapExtra() uint64 {
 // }
 
 func (m *BPFMap) InitialValue() ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -227,7 +227,7 @@ func (m *BPFMap) InitialValue() ([]byte, error) {
 }
 
 func (m *BPFMap) SetInitialValue(value unsafe.Pointer) error {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -384,7 +384,7 @@ func (m *BPFMap) GetValue(key unsafe.Pointer) ([]byte, error) {
 }
 
 func (m *BPFMap) GetValueFlags(key unsafe.Pointer, flags MapFlag) ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -439,7 +439,7 @@ func (m *BPFMap) GetValueAndDeleteKey(key unsafe.Pointer) ([]byte, error) {
 // and delete the key in the BPFMap, with the specified flags.
 // It returns the value as a slice of bytes.
 func (m *BPFMap) GetValueAndDeleteKeyFlags(key unsafe.Pointer, flags MapFlag) ([]byte, error) {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return nil, fmt.Errorf("map %s %w", m.Name(), err)
 	}
@@ -486,7 +486,7 @@ func (m *BPFMap) Update(key, value unsafe.Pointer) error {
 }
 
 func (m *BPFMap) UpdateValueFlags(key, value unsafe.Pointer, flags MapFlag) error {
-	valueSize, err := calcMapValueSize(m.ValueSize(), m.Type())
+	valueSize, err := CalcMapValueSize(m.ValueSize(), m.Type())
 	if err != nil {
 		return fmt.Errorf("map %s %w", m.Name(), err)
 	}


### PR DESCRIPTION
This is a continuation of https://github.com/aquasecurity/libbpfgo/pull/411

See https://github.com/aquasecurity/libbpfgo/pull/411#issuecomment-2039654932

commit a769590a18d35f5b03d37fa934c085cc91586aa2

    feat(map): make CalcMapValueSize a public helper
    
    Signed-off-by: Geyslan Gregório <geyslan@gmail.com>

commit b9543a4ea11769d3c4f9aa8f46272b945ac10479

    feat(map): Add GetNextKey and LookupAndDeleteElem
    
    For BPFMapLow add the following wrapper methods:
    
    GetNextKey() -> bpf_map_get_next_key()
    LookupAndDeleteElem() -> bpf_map_lookup_and_delete_elem()
    LookupAndDeleteElemFlags() -> bpf_map_lookup_and_delete_elem_flags()
    
    In addition, introduce GetValueAndDeleteKey() and
    GetValueAndDeleteKeyFlags() helper methods to BPFMapLow which return
    a pre-allocated lookup value automatically.
    
    For BPFMap add the following wrapper methods:
    
    GetNextKey() -> bpf_map__get_next_key()
    LookupAndDeleteElem() -> bpf_map__lookup_and_delete_elem()
    
    As for BPFMapLow, introduce GetValueAndDeleteKey() and
    GetValueAndDeleteKeyFlags() helper methods to BPFMap.
    
    Signed-off-by: Tao Chen <chen.dylane@gmail.com>
    Co-authored-by: Geyslan Gregório <geyslan@gmail.com>