### PR TITLE
chore(selftest): Add tc Query test case

### DIFF
--- a/selftest/tc/main.go
+++ b/selftest/tc/main.go
@@ -54,7 +54,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	var tcOpts bpf.TcOpts
+	var tcOpts bpf.TcOpts // https://elixir.bootlin.com/linux/v6.8.4/source/tools/testing/selftests/bpf/prog_tests/tc_bpf.c#L26
 	tcOpts.ProgFd = int(tcProg.GetFd())
 	tcOpts.Handle = 1
 	tcOpts.Priority = 1


### PR DESCRIPTION
The bpf_tc_query interface should init the parameter first, sometimes it may be confused for us, so add the test case to reduce the confusion.

Close: https://github.com/aquasecurity/libbpfgo/issues/421