### PR TITLE
feat: AddRingBuf() using ring_buffer__add

### DIFF
--- a/libbpfgo.c
+++ b/libbpfgo.c
@@ -59,6 +59,20 @@ struct ring_buffer *cgo_init_ring_buf(int map_fd, uintptr_t ctx)
     return rb;
 }
 
+int cgo_add_ring_buf(struct ring_buffer *rb, int map_fd, uintptr_t ctx)
+{
+    int ret = ring_buffer__add(rb, map_fd, ringbufferCallback, (void *) ctx);
+    if (ret != 0) {
+        int saved_errno = errno;
+        fprintf(stderr, "Failed to add ring buffer: %s\n", strerror(errno));
+        errno = saved_errno;
+
+        return ret;
+    }
+
+    return ret;
+}
+
 struct perf_buffer *cgo_init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx)
 {
     struct perf_buffer_opts pb_opts = {};

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -21,6 +21,7 @@
 void cgo_libbpf_set_print_fn();
 
 struct ring_buffer *cgo_init_ring_buf(int map_fd, uintptr_t ctx);
+int cgo_add_ring_buf(struct ring_buffer *rb, int map_fd, uintptr_t ctx);
 struct perf_buffer *cgo_init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx);
 
 void cgo_bpf_map__initial_value(struct bpf_map *map, void *value);

--- a/selftest/ringbuffers/main.bpf.c
+++ b/selftest/ringbuffers/main.bpf.c
@@ -8,7 +8,7 @@
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 24);
-} events SEC(".maps");
+} events1 SEC(".maps"), events2 SEC(".maps");
 
 long ringbuffer_flags = 0;
 
@@ -18,12 +18,21 @@ int kprobe__sys_mmap(struct pt_regs *ctx)
     int *process;
 
     // Reserve space on the ringbuffer for the sample
-    process = bpf_ringbuf_reserve(&events, sizeof(int), ringbuffer_flags);
+    process = bpf_ringbuf_reserve(&events1, sizeof(int), ringbuffer_flags);
     if (!process) {
         return 0;
     }
 
     *process = 2021;
+
+    bpf_ringbuf_submit(process, ringbuffer_flags);
+
+    process = bpf_ringbuf_reserve(&events2, sizeof(int), ringbuffer_flags);
+    if (!process) {
+        return 0;
+    }
+
+    *process = 2024;
 
     bpf_ringbuf_submit(process, ringbuffer_flags);
     return 0;


### PR DESCRIPTION
libbpf provides ring_buffer__add to handle multiple ringbuf event callbacks

- single RingBuffer object now handles multiple slots
- implements AddRingBuf() for ring_buffer__add wrapper
- updates ringbuffers selftest to show how to handle it

Reference
- https://github.com/torvalds/linux/blob/eb6a9339efeb6f3d2b5c86fdf2382cdc293eca2c/tools/testing/selftests/bpf/progs/test_ringbuf_multi.c
- https://github.com/torvalds/linux/blob/eb6a9339efeb6f3d2b5c86fdf2382cdc293eca2c/tools/testing/selftests/bpf/prog_tests/ringbuf_multi.c#41