### PR TITLE
chore(prog): Add attach/detach legacy api for xdp

### DIFF
--- a/libbpfgo.c
+++ b/libbpfgo.c
@@ -493,3 +493,21 @@ __u32 cgo_bpf_tc_opts_priority(struct bpf_tc_opts *opts)
 
     return opts->priority;
 }
+
+struct bpf_xdp_attach_opts *cgo_bpf_xdp_attach_opts_new(__u32 fd)
+{
+    struct bpf_xdp_attach_opts *opts;
+    opts = calloc(1, sizeof(*opts));
+
+    if (!opts)
+        return NULL;
+    opts->sz = sizeof(*opts);
+    opts->old_prog_fd = fd;
+
+    return opts;
+}
+
+void cgo_bpf_xdp_attach_opts_free(struct bpf_xdp_attach_opts *opts)
+{
+    free(opts);
+}

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -16,7 +16,8 @@
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
-#include <linux/bpf.h> // uapi
+#include <linux/bpf.h>     // uapi
+#include <linux/if_link.h> // uapi
 
 void cgo_libbpf_set_print_fn();
 
@@ -107,5 +108,10 @@ __u32 cgo_bpf_tc_opts_flags(struct bpf_tc_opts *opts);
 __u32 cgo_bpf_tc_opts_prog_id(struct bpf_tc_opts *opts);
 __u32 cgo_bpf_tc_opts_handle(struct bpf_tc_opts *opts);
 __u32 cgo_bpf_tc_opts_priority(struct bpf_tc_opts *opts);
+
+// bpf_xdp_attach_opts
+
+struct bpf_xdp_attach_opts *cgo_bpf_xdp_attach_opts_new(__u32 fd);
+void cgo_bpf_xdp_attach_opts_free(struct bpf_xdp_attach_opts *opts);
 
 #endif

--- a/prog-common.go
+++ b/prog-common.go
@@ -237,3 +237,19 @@ const (
 	BPFFAllowMulti    AttachFlag = C.BPF_F_ALLOW_MULTI
 	BPFFReplace       AttachFlag = C.BPF_F_REPLACE
 )
+
+//
+// XDPFlags
+//
+
+type XDPFlags uint32
+
+const (
+	XDPFlagsUpdateIfNoExist XDPFlags = C.XDP_FLAGS_UPDATE_IF_NOEXIST
+	XDPFlagsSkbMode         XDPFlags = C.XDP_FLAGS_SKB_MODE
+	XDPFlagsDrvMode         XDPFlags = C.XDP_FLAGS_DRV_MODE
+	XDPFlagsHwMode          XDPFlags = C.XDP_FLAGS_HW_MODE
+	XDPFlagsReplace         XDPFlags = C.XDP_FLAGS_REPLACE
+	XDPFlagsModes           XDPFlags = C.XDP_FLAGS_MODES
+	XDPFlagsMask            XDPFlags = C.XDP_FLAGS_MASK
+)

--- a/selftest/xdp/main.go
+++ b/selftest/xdp/main.go
@@ -35,6 +35,17 @@ func main() {
 		os.Exit(-1)
 	}
 
+	err = xdpProg.AttachXDPLegacy(deviceName, bpf.XDPFlagsReplace)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+	err = xdpProg.DetachXDPLegacy(deviceName, bpf.XDPFlagsReplace)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+
 	_, err = xdpProg.AttachXDP(deviceName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
The AttachXDP api use bpf link to attach xdp prog, AttachXDPLegacy/DetachXDPLegacy apis corresponds to bpf_xdp_attach/bpf_xdp_detach, which can be used on old kernel, so add it.