### PR TITLE
fix: set 'elf' to nil after closing in BPFLoadObject for GC

### DIFF
--- a/module.go
+++ b/module.go
@@ -202,6 +202,7 @@ func (m *Module) BPFLoadObject() error {
 	}
 	m.loaded = true
 	m.elf.Close()
+	m.elf = nil
 
 	return nil
 }


### PR DESCRIPTION
In the BPFLoadObject function, the 'elf' field is closed, but it is not set to nil. Setting it to nil is necessary for it to be freed by the garbage collector.