### PR TITLE
Bump deps (align helpers testify & psx fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,6 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 h1:cTgLaDzZqsIoKDomWTT6GEKKIdowAz5gwfKhfKhRP50=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.75/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 h1:Tq5hYNtVgkIUTv+5BtOZjC5JB4s8TutijJE5vBaoW84=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/helpers/go.mod
+++ b/helpers/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/libbpfgo/helpers
 go 1.21
 
 require (
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.25.0
 )
 

--- a/helpers/go.sum
+++ b/helpers/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/selftest/probe-ringbuf-non-supported/go.sum
+++ b/selftest/probe-ringbuf-non-supported/go.sum
@@ -6,7 +6,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73 h1:Th2b8jljYqkyZKS3aD3N9VpYsQpHuXLgea+SZUIfODA=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73/go.mod h1:hbeKwKcboEsxARYmcy/AdPVN11wmT/Wnpgv4k4ftyqY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 h1:SEAEUiPVylTD4vqqi+vtGkSnXeP2FcRO3FoZB1MklMw=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 h1:Tq5hYNtVgkIUTv+5BtOZjC5JB4s8TutijJE5vBaoW84=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=

--- a/selftest/probe-ringbuf/go.sum
+++ b/selftest/probe-ringbuf/go.sum
@@ -6,7 +6,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73 h1:Th2b8jljYqkyZKS3aD3N9VpYsQpHuXLgea+SZUIfODA=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73/go.mod h1:hbeKwKcboEsxARYmcy/AdPVN11wmT/Wnpgv4k4ftyqY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 h1:SEAEUiPVylTD4vqqi+vtGkSnXeP2FcRO3FoZB1MklMw=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 h1:Tq5hYNtVgkIUTv+5BtOZjC5JB4s8TutijJE5vBaoW84=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=


### PR DESCRIPTION
commit e179c28020ac048d0c816e4ba3ecb9c2c3998b50

    fix(deps): bump psx to v1.2.76-rc1
    
    - https://github.com/aquasecurity/tracee/pull/4688#issuecomment-2764255447
    - https://web.git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?h=psx/v1.2.76-rc1&id=07d8ce731d5fe9063abfef4a77306e273b18b5f3

commit 1aba1ea4a5bf73c8aa01c92855563c75b5ddcb87

    chore(helpers): reduce gomod noise syncing with main