### PR TITLE
fix(prog)!: AttachUprobe and AttachURetprobe signatures

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -607,7 +607,7 @@ func (p *BPFProg) AttachIter(opts IterOpts) (*BPFLink, error) {
 // AttachUprobe attaches the BPFProgram to entry of the symbol in the library or binary at 'path'
 // which can be relative or absolute. A pid can be provided to attach to, or -1 can be specified
 // to attach to all processes
-func (p *BPFProg) AttachUprobe(pid int, path string, offset uint32) (*BPFLink, error) {
+func (p *BPFProg) AttachUprobe(pid int, path string, offset uint64) (*BPFLink, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
@@ -619,7 +619,7 @@ func (p *BPFProg) AttachUprobe(pid int, path string, offset uint32) (*BPFLink, e
 // AttachURetprobe attaches the BPFProgram to exit of the symbol in the library or binary at 'path'
 // which can be relative or absolute. A pid can be provided to attach to, or -1 can be specified
 // to attach to all processes
-func (p *BPFProg) AttachURetprobe(pid int, path string, offset uint32) (*BPFLink, error) {
+func (p *BPFProg) AttachURetprobe(pid int, path string, offset uint64) (*BPFLink, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
@@ -656,7 +656,7 @@ func (p *BPFProg) AttachURetprobeMulti(pid int, path string, offsets, cookies []
 	return doAttachUprobeMulti(p, true, pid, absPath, offsets, cookies)
 }
 
-func doAttachUprobe(prog *BPFProg, isUretprobe bool, pid int, path string, offset uint32) (*BPFLink, error) {
+func doAttachUprobe(prog *BPFProg, isUretprobe bool, pid int, path string, offset uint64) (*BPFLink, error) {
 	pathC := C.CString(path)
 	defer C.free(unsafe.Pointer(pathC))
 

--- a/selftest/uprobe/main.go
+++ b/selftest/uprobe/main.go
@@ -91,7 +91,7 @@ recvLoop:
 
 // symbolToOffset attempts to resolve a 'symbol' name in the binary found at
 // 'path' to an offset. The offset can be used for attaching a u(ret)probe
-func symbolToOffset(path, symbol string) (uint32, error) {
+func symbolToOffset(path, symbol string) (uint64, error) {
 	f, err := elf.Open(path)
 	if err != nil {
 		return 0, fmt.Errorf("could not open elf file to resolve symbol offset: %w", err)
@@ -135,7 +135,7 @@ func symbolToOffset(path, symbol string) (uint32, error) {
 				return 0, errors.New("could not find symbol in executable sections of binary")
 			}
 
-			return uint32(syms[j].Value - executableSection.Addr + executableSection.Offset), nil
+			return syms[j].Value - executableSection.Addr + executableSection.Offset, nil
 		}
 	}
 


### PR DESCRIPTION
4dc6ec79d29899982361f8090b4667cc867dfbcf

    fix(prog)!: AttachUprobe and AttachURetprobe signatures
    
    offset is size_t, therefore it is 8 bytes.
    
    BREAKING CHANGE: This changes the signature of AttachUprobe and
    AttachURetprobe.