### PR TITLE
fix(selftest/iter): remove flaky ppid check

### DIFF
--- a/selftest/iter/main.bpf.c
+++ b/selftest/iter/main.bpf.c
@@ -21,7 +21,7 @@ int iter__task(struct bpf_iter__task *ctx)
             return 0;
     }
 
-    BPF_SEQ_PRINTF(seq, "%d\t%d\t%s\n", task->parent->pid, task->pid, task->comm);
+    BPF_SEQ_PRINTF(seq, "%d\t%s\n", task->pid, task->comm);
     return 0;
 }
 


### PR DESCRIPTION
ddea4ced00838eb09383aade0bbb639b9c9b6912 fix(selftest/iter): remove flaky ppid check
    
    The parent PID validation is intermittently failing due to kernel
    process management and Go runtime behavior. The sleep processes may be
    reparented to intermediate executor processes (observed PPID differences
    of 3-5 PIDs) during process creation or the selftest process might be
    moved to a different host thread, causing false test failures.
    
    Since the BPF iterator already correctly filters processes by name
    ("sleep"), the strict parent PID check is unnecessary and makes the test
    brittle against normal Go process lifecycle variations.
    
    Fixes intermittent CI failures where expected PPID != actual PPID.
    
    https://github.com/aquasecurity/libbpfgo/actions/runs/17275771026/job/49031931916?pr=503#step:4:4894
    
    2025/08/27 18:49:58 Sleeping 1 second to ensure iterator is ready...
    2025/08/27 18:49:59 Starting 10 sleep processes...
    2025/08/27 18:49:59 Started sleep process with PID 17635, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17636, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17637, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17638, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17639, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17640, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17641, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17642, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17643, parent PID 17629
    2025/08/27 18:49:59 Started sleep process with PID 17644, parent PID 17629
    2025/08/27 18:49:59 Sleeping for 5 seconds to allow processes to register...
    2025/08/27 18:50:04 Reading iterator output:
    2025/08/27 18:50:04 [iter] 17632        17635   sleep
    2025/08/27 18:50:04 [iter] 17632        17636   sleep
    2025/08/27 18:50:04 [iter] 17632        17637   sleep
    2025/08/27 18:50:04 [iter] 17632        17638   sleep
    2025/08/27 18:50:04 [iter] 17632        17639   sleep
    2025/08/27 18:50:04 [iter] 17632        17640   sleep
    2025/08/27 18:50:04 [iter] 17632        17641   sleep
    2025/08/27 18:50:04 [iter] 17632        17642   sleep
    2025/08/27 18:50:04 [iter] 17632        17643   sleep
    2025/08/27 18:50:04 [iter] 17632        17644   sleep
    2025/08/27 18:50:04 ERROR: /home/runner/work/libbpfgo/libbpfgo/selftest/iter/main.go:113 expect numberOfMatches == 10 but got 0