### PR TITLE
feat(maps): add error for no inner map

### DIFF
--- a/selftest/map-innerinfo/main.bpf.c
+++ b/selftest/map-innerinfo/main.bpf.c
@@ -11,7 +11,7 @@ struct inner_map {
     __uint(max_entries, 1);
     __type(key, __u32);
     __type(value, __u32);
-} inner_map1 SEC(".maps"), inner_map2 SEC(".maps");
+} proto_map1 SEC(".maps"), proto_map2 SEC(".maps");
 
 struct outer_hash {
     __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
@@ -21,8 +21,8 @@ struct outer_hash {
 } outer_hash SEC(".maps") = {
     .values =
         {
-            [0] = &inner_map2,
-            [4] = &inner_map1,
+            [0] = &proto_map2,
+            [4] = &proto_map1,
         },
 };
 

--- a/selftest/map-innerinfo/main.go
+++ b/selftest/map-innerinfo/main.go
@@ -53,6 +53,22 @@ func main() {
 		common.Error(fmt.Errorf("inner prototype map extra should be 0: %d", innerInfo.MapExtra))
 	}
 
+	// Test that calling InnerMapInfo() on a regular map (not map-of-maps) returns ErrNoInnerMap
+	protoMap1, err := bpfModule.GetMap("proto_map1")
+	if err != nil {
+		common.Error(err)
+	}
+	_, err = protoMap1.InnerMapInfo()
+	if !errors.Is(err, bpf.ErrNoInnerMap) {
+		common.Error(fmt.Errorf("expected ErrNoInnerMap for regular map, got: %v", err))
+	}
+
+	// Test calling InnerMapInfo() from a map-of-maps
+	_, err = outerHash.InnerMapInfo()
+	if err != nil {
+		common.Error(fmt.Errorf("expected no error for map-of-maps, got: %v", err))
+	}
+
 	err = bpfModule.BPFLoadObject()
 	if err != nil {
 		common.Error(err)


### PR DESCRIPTION
Use a defined error for calling InnerMapInfo for a map which has no inner map. This allow the caller to distinguish between error in logic to a call on an unsupported map.