### PR TITLE
feat: added BPFReplaceExistedObject

### DIFF
--- a/module.go
+++ b/module.go
@@ -211,6 +211,11 @@ func (m *Module) BPFLoadObject() error {
 	return nil
 }
 
+func (m *Module) BPFReplaceExistedObject(obj unsafe.Pointer) error {
+	m.obj = (*C.struct_bpf_object)(obj)
+	return nil
+}
+
 // InitGlobalVariable sets global variables (defined in .data or .rodata)
 // in bpf code. It must be called before the BPF object is loaded.
 func (m *Module) InitGlobalVariable(name string, value interface{}) error {

--- a/module.go
+++ b/module.go
@@ -211,8 +211,13 @@ func (m *Module) BPFLoadObject() error {
 	return nil
 }
 
+// Replace existing BPF object
+// It helps to inject the eBPF skeleton file for replacing the loaded obj
 func (m *Module) BPFReplaceExistingObject(obj unsafe.Pointer) error {
 	m.obj = (*C.struct_bpf_object)(obj)
+	if m.obj == nil {
+		return fmt.Errorf("BPFReplaceExistingObject failed")
+	}
 	return nil
 }
 

--- a/module.go
+++ b/module.go
@@ -211,7 +211,7 @@ func (m *Module) BPFLoadObject() error {
 	return nil
 }
 
-func (m *Module) BPFReplaceExistedObject(obj unsafe.Pointer) error {
+func (m *Module) BPFReplaceExistingObject(obj unsafe.Pointer) error {
 	m.obj = (*C.struct_bpf_object)(obj)
 	return nil
 }


### PR DESCRIPTION
All of the variables located in the rodata/bss section will be mapped into an eBPF map during the eBPF program's runtime.
And there are some known limitations:
1. The rodata section can only be overwritten before the eBPF program is attached.
2. The BSS section can be modified via MAP Update. But the data synchronization can't be guaranteed.

It was a significant challenge when I attempted to implement the user-space scheduler in Go.
My solution is to use the cgo to call eBPF skeleton APIs, so I need an additional wrapper to replace the existing eBPF object before the program attaches.

=== example ===

```go
// ...

func LoadSkel() unsafe.Pointer {
	return C.open_skel()
}

func LoadSched(objPath string) *Sched {
	obj := LoadSkel()
	bpfModule, err := bpf.NewModuleFromFileArgs(bpf.NewModuleArgs{
		BPFObjPath:     "",
		KernelLogLevel: 0,
	})
	if err != nil {
		panic(err)
	}
	if err := bpfModule.BPFReplaceExistedObject(obj); err != nil {
		panic(err)
	}

	s := &Sched{
		mod: bpfModule,
	}

	return s
}

func (s *Sched) SetBuiltinIdle(enabled bool) {
	C.set_builtin_idle(C.bool(enabled))
}

func (s *Sched) Attach() error {
	_, err := s.structOps.AttachStructOps()
	return err
}
```

```c
void set_builtin_idle(bool enabled) {
    global_obj->rodata->builtin_idle = enabled;
}
```

Therefore, I can call `SetBuiltinIdle()` before `Attach()` to modify the target variable `builtin_idle` in the rodata section.