### PR TITLE
Resolve sporadic ENOSPC errors in map-batch tests and more...

### DIFF
--- a/selftest/common/common.go
+++ b/selftest/common/common.go
@@ -60,6 +60,35 @@ func ByteOrder() binary.ByteOrder {
 	return binary.BigEndian
 }
 
+// GetKernelVersion returns the kernel version string from /proc/version.
+// It returns the full version string or "unknown" if it cannot be read.
+func GetKernelVersion() string {
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return "unknown"
+	}
+
+	return strings.TrimSpace(string(data))
+}
+
+// GetKernelRelease returns the kernel release string from /proc/version.
+// It extracts just the version number (e.g., "5.7.0-050700-generic") from the full version string.
+// Returns "unknown" if the version cannot be parsed.
+func GetKernelRelease() string {
+	version := GetKernelVersion()
+	if version == "unknown" {
+		return "unknown"
+	}
+
+	// Parse "Linux version X.Y.Z-..." from the version string
+	parts := strings.Fields(version)
+	if len(parts) >= 3 && parts[0] == "Linux" && parts[1] == "version" {
+		return parts[2]
+	}
+
+	return "unknown"
+}
+
 var reCgroup2Mount = regexp.MustCompile(`(?m)^cgroup2\s(/\S+)\scgroup2\s`)
 
 // GetCgroupV2RootDir returns the root directory of the cgroupv2 filesystem.

--- a/selftest/common/run-vm-stage2.sh
+++ b/selftest/common/run-vm-stage2.sh
@@ -11,4 +11,5 @@ check_build
 test_exec
 test_finish
 
-exit 0
+# Don't override the exit code from test_finish
+exit $?

--- a/selftest/map-batch/main.go
+++ b/selftest/map-batch/main.go
@@ -31,7 +31,10 @@ func main() {
 	// UpdateBatch
 	//
 
+	log.Printf("[TEST] Starting UpdateBatch tests")
+
 	// Test batch update.
+	log.Printf("[TEST] UpdateBatch: Testing basic batch update")
 	keys := []uint32{1, 2, 3, 4}
 	values := []uint32{2, 3, 4, 5}
 
@@ -57,6 +60,7 @@ func main() {
 
 	// Test batch update.
 	// Trying to update more entries than max_entries.
+	log.Printf("[TEST] UpdateBatch: Testing overflow (more entries than max_entries)")
 	keysGreater := []uint32{1, 2, 3, 4, 100} // 100 won't be added, since max_entries is 4.
 	valuesGreater := []uint32{2, 3, 4, 5, 100}
 
@@ -76,7 +80,10 @@ func main() {
 	// GetValueBatch
 	//
 
+	log.Printf("[TEST] Starting GetValueBatch tests")
+
 	// Test batch lookup in steps.
+	log.Printf("[TEST] GetValueBatch: Testing iterative batch lookup")
 	batchKeys := make([]uint32, 3)
 	startKeyPtr := unsafe.Pointer(nil)
 	nextKey := uint64(0)
@@ -88,7 +95,12 @@ func main() {
 			unsafe.Pointer(&nextKey),
 			uint32(stepSize),
 		)
+
 		if err != nil {
+			// ENOENT means we've finished iterating through all elements
+			if errors.Is(err, syscall.ENOENT) {
+				break
+			}
 			common.Error(fmt.Errorf("failed to batch lookup: %v", err))
 		}
 
@@ -98,51 +110,87 @@ func main() {
 			actual := common.ByteOrder().Uint32(val)
 			expected := batchKeys[i] + 1
 			if actual != expected {
-				common.Error(fmt.Errorf("testerMap.GetValueBatch returned %v, expected %v", actual, expected))
+				common.Error(fmt.Errorf("GetValueBatch returned %v, expected %v", actual, expected))
 			}
 		}
 	}
 
-	// Test batch lookup an unavailable key between available keys.
-	notAllAvailableKeys := []uint32{10, 1, 2, 3, 4} // 10 is not in the map.
-	expectedCount := uint32(len(notAllAvailableKeys) - 1)
+	// Test batch lookup with larger batch size than map content
+	// This should return all elements in the map
+	log.Printf("[TEST] GetValueBatch: Testing with large batch size")
+	largeBatchKeys := make([]uint32, 10) // Larger than map size (4)
 	startKeyPtr = unsafe.Pointer(nil)
 	nextKey = uint64(0)
-	_, count, err = testerMap.GetValueBatch(
-		unsafe.Pointer(&notAllAvailableKeys[0]),
+
+	var batchCount uint32
+	_, batchCount, err = testerMap.GetValueBatch(
+		unsafe.Pointer(&largeBatchKeys[0]),
 		startKeyPtr,
 		unsafe.Pointer(&nextKey),
-		uint32(len(notAllAvailableKeys)),
+		uint32(len(largeBatchKeys)),
 	)
+
 	if err != nil {
 		common.Error(err)
 	}
-	if count != expectedCount {
-		common.Error(fmt.Errorf("failed to partial batch lookup elements: %d/%d", count, expectedCount))
+	// Should get exactly 4 elements (the size of our map)
+	if batchCount != 4 {
+		common.Error(fmt.Errorf("expected to get 4 elements, got %d", batchCount))
 	}
 
-	// Test batch lookup passing a count that is greater than the number of
-	// available elements.
+	// Test batch lookup starting from a non-existent key
+	// This tests iteration behavior when startKey doesn't exist in the map
+	log.Printf("[TEST] GetValueBatch: Testing iteration starting from non-existent key")
+	nonExistentKey := uint32(100) // This key is not in the map
+	iterationKeys := make([]uint32, 4)
+	startKeyPtr = unsafe.Pointer(&nonExistentKey)
+	nextKey = uint64(0)
+
+	_, iterationCount, err := testerMap.GetValueBatch(
+		unsafe.Pointer(&iterationKeys[0]),
+		startKeyPtr,
+		unsafe.Pointer(&nextKey),
+		uint32(len(iterationKeys)),
+	)
+
+	if err != nil && !errors.Is(err, syscall.ENOENT) {
+		common.Error(fmt.Errorf("GetValueBatch with non-existent start key failed: %v", err))
+	}
+	// Should either find some keys (if iteration continues past non-existent key)
+	// or return ENOENT (if no more keys), both are valid behaviors
+	log.Printf("[TEST] GetValueBatch: Non-existent key iteration returned %d elements", iterationCount)
+
+	// Test batch lookup with count greater than available elements.
+	log.Printf("[TEST] GetValueBatch: Testing with count greater than available elements")
 	greaterCount := len(batchKeys) + 10
 	startKeyPtr = unsafe.Pointer(nil)
 	nextKey = uint64(0)
-	_, count, err = testerMap.GetValueBatch(
+
+	_, _, err = testerMap.GetValueBatch(
 		unsafe.Pointer(&batchKeys[0]),
 		startKeyPtr,
 		unsafe.Pointer(&nextKey),
 		uint32(greaterCount),
 	)
+
 	if err != nil {
-		common.Error(err)
+		// ENOENT is expected if iteration is already complete
+		if !errors.Is(err, syscall.ENOENT) {
+			common.Error(err)
+		}
 	}
 
 	//
 	// GetValueAndDeleteBatch
 	//
 
+	log.Printf("[TEST] Starting GetValueAndDeleteBatch tests")
+
 	// Test batch lookup and delete in steps.
-	totalKeysToDelete := uint32(3)
+	// We should have 4 keys in the map at this point: [1, 2, 3, 4]
+	totalKeysToDelete := uint32(4)
 	stepSize = 1
+	log.Printf("[TEST] GetValueAndDeleteBatch: Attempting to delete %d keys starting with batch size %d", totalKeysToDelete, stepSize)
 	step := 0
 	for totalKeysToDelete > 0 && step < 10 {
 		if totalKeysToDelete < uint32(stepSize) {
@@ -159,10 +207,13 @@ func main() {
 		)
 		if err != nil {
 			if errors.Is(err, syscall.ENOSPC) {
+				// ENOSPC occurs when hash bucket contains more elements than batch size
 				// Reference:
 				// https://elixir.bootlin.com/linux/v6.4.13/source/tools/testing/selftests/bpf/map_tests/htab_map_batch_ops.c#L158
-				log.Printf("totalKeysToDelete: %d, step: %d, stepSize: %d", totalKeysToDelete, step, stepSize)
 				if uint32(stepSize) < totalKeysToDelete {
+					log.Printf("[ENOSPC] GetValueAndDeleteBatch: Hash bucket collision detected.\n"+
+						"  Remaining keys: %d, retry step: %d, current batch size: %d, increasing to: %d",
+						totalKeysToDelete, step, stepSize, stepSize+1)
 					stepSize++
 				}
 
@@ -171,14 +222,14 @@ func main() {
 			}
 			common.Error(err)
 		}
-		log.Printf("testerMap.GetValueAndDeleteBatch deleted element(s): %d", count)
+		log.Printf("GetValueAndDeleteBatch deleted element(s): %d", count)
 		totalKeysToDelete -= count
 
 		for i, val := range vals {
 			actual := common.ByteOrder().Uint32(val)
 			expected := deleteKeys[i] + 1
 			if actual != expected {
-				common.Error(fmt.Errorf("testerMap.GetValueAndDeleteBatch returned %v, expected %v", actual, expected))
+				common.Error(fmt.Errorf("GetValueAndDeleteBatch returned %v, expected %v", actual, expected))
 			}
 		}
 	}
@@ -191,7 +242,10 @@ func main() {
 	// DeleteKeyBatch
 	//
 
+	log.Printf("[TEST] Starting DeleteKeyBatch tests")
+
 	// Re-add deleted entries.
+	log.Printf("[TEST] DeleteKeyBatch: Re-adding entries for testing")
 	_, err = testerMap.UpdateBatch(
 		unsafe.Pointer(&keys[0]),
 		unsafe.Pointer(&values[0]),
@@ -205,6 +259,7 @@ func main() {
 
 	// Test batch delete.
 	// Trying to delete more keys than we have.
+	log.Printf("[TEST] DeleteKeyBatch: Testing delete more keys than available")
 	count, err = testerMap.DeleteKeyBatch(
 		unsafe.Pointer(&keys[0]),
 		uint32(len(keys)+10),
@@ -236,6 +291,7 @@ func main() {
 
 	// Test batch delete.
 	// Trying to delete fewer or equal keys than we have.
+	log.Printf("[TEST] DeleteKeyBatch: Testing delete fewer keys than available")
 	fewer := 3
 	count, err = testerMap.DeleteKeyBatch(
 		unsafe.Pointer(&keys[0]),
@@ -251,6 +307,7 @@ func main() {
 	// map contains only 1 key-value pair.
 
 	// Re-add deleted entries.
+	log.Printf("[TEST] DeleteKeyBatch: Re-adding entries for GetNextKey test")
 	_, err = testerMap.UpdateBatch(
 		unsafe.Pointer(&keys[0]),
 		unsafe.Pointer(&values[0]),
@@ -264,7 +321,10 @@ func main() {
 	// GetNextKey
 	//
 
+	log.Printf("[TEST] Starting GetNextKey tests")
+
 	// Populate the map again.
+	log.Printf("[TEST] GetNextKey: Populating map for iteration test")
 	_, err = testerMap.UpdateBatch(
 		unsafe.Pointer(&keys[0]),
 		unsafe.Pointer(&values[0]),
@@ -275,6 +335,7 @@ func main() {
 	}
 
 	// Test GetNextKey.
+	log.Printf("[TEST] GetNextKey: Testing key iteration")
 	key := uint32(0)
 	keyPtr := unsafe.Pointer(&key)
 	keyCnt := 0
@@ -296,7 +357,10 @@ func main() {
 	// GetValueAndDeleteKey
 	//
 
+	log.Printf("[TEST] Starting GetValueAndDeleteKey tests")
+
 	// Test GetValueAndDeleteKey.
+	log.Printf("[TEST] GetValueAndDeleteKey: Testing individual key deletion")
 	for i, key := range keys {
 		val, err := testerMap.GetValueAndDeleteKey(unsafe.Pointer(&key))
 		if err != nil {
@@ -309,9 +373,12 @@ func main() {
 	}
 
 	// Check if all keys are deleted.
+	log.Printf("[TEST] GetValueAndDeleteKey: Verifying all keys are deleted")
 	key = 0
 	err = testerMap.GetNextKey(keyPtr, keyPtr)
 	if !errors.Is(err, syscall.ENOENT) {
 		common.Error(fmt.Errorf("testerMap.GetValueAndDeleteKey failed: err=%v", err))
 	}
+
+	log.Printf("[TEST] All map-batch tests completed successfully!")
 }

--- a/selftest/probe-features/main.go
+++ b/selftest/probe-features/main.go
@@ -4,12 +4,18 @@ import "C"
 
 import (
 	"errors"
+	"log"
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/selftest/common"
 )
 
 func main() {
+	kernelVersion := common.GetKernelVersion()
+	kernelRelease := common.GetKernelRelease()
+	log.Printf("Running on kernel: %s", kernelVersion)
+	log.Printf("Kernel release: %s", kernelRelease)
+
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {
 		common.Error(err)
@@ -27,6 +33,7 @@ func main() {
 	}
 
 	isSupported, err := bpf.BPFProgramTypeIsSupported(bpf.BPFProgTypeKprobe)
+	log.Printf("BPFProgramTypeIsSupported(BPFProgTypeKprobe) returned: isSupported=%v, err=%v", isSupported, err)
 	if err != nil {
 		common.Error(err)
 	}
@@ -52,6 +59,7 @@ func main() {
 	}
 
 	isSupported, err = bpf.BPFMapTypeIsSupported(bpf.MapTypeHash)
+	log.Printf("BPFMapTypeIsSupported(MapTypeHash) returned: isSupported=%v, err=%v", isSupported, err)
 	if err != nil {
 		common.Error(err)
 	}

--- a/selftest/probe-ringbuf-non-supported/main.go
+++ b/selftest/probe-ringbuf-non-supported/main.go
@@ -9,10 +9,27 @@ import (
 )
 
 func main() {
+	kernelVersion := common.GetKernelVersion()
+	kernelRelease := common.GetKernelRelease()
+	log.Printf("Running on kernel: %s", kernelVersion)
+	log.Printf("Kernel release: %s", kernelRelease)
+
 	// Should not be supported before 5.8
 	isSupported, err := bpf.BPFMapTypeIsSupported(bpf.MapTypeRingbuf)
-	if err == nil || isSupported {
-		common.Error(errors.New("ringbuf is supported unexpectedly or no error"))
+
+	log.Printf("BPFMapTypeIsSupported(MapTypeRingbuf) returned: isSupported=%v, err=%v", isSupported, err)
+
+	// Handle any error from the BPF probing function itself
+	if err != nil {
+		log.Printf("Ringbuf probing returned an error as expected: %v", err)
+		return // This is expected behavior for unsupported features
+	}
+
+	// We expect isSupported = false with no error
+	if isSupported {
+		log.Printf("WARNING: ringbuf is unexpectedly supported on this kernel")
+		log.Printf("This may indicate a libbpf probing issue or kernel backport")
+		common.Error(errors.New("ringbuf is unexpectedly supported on this kernel (expected not supported before 5.8)"))
 	}
 
 	log.Println("Ringbuf is not supported as expected")

--- a/selftest/probe-ringbuf-non-supported/run.sh
+++ b/selftest/probe-ringbuf-non-supported/run.sh
@@ -7,7 +7,7 @@ KERNEL_VERSION=v5.7    # kernel version
 # SETTINGS
 COMMON="$(dirname $0)/../common/common.sh"
 
-vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
+vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --append "psi=0" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
 # Don't override the exit code from the VM
 exit $?

--- a/selftest/probe-ringbuf-non-supported/run.sh
+++ b/selftest/probe-ringbuf-non-supported/run.sh
@@ -9,4 +9,5 @@ COMMON="$(dirname $0)/../common/common.sh"
 
 vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
-exit 0
+# Don't override the exit code from the VM
+exit $?

--- a/selftest/probe-ringbuf/main.go
+++ b/selftest/probe-ringbuf/main.go
@@ -3,11 +3,19 @@ package main
 import "C"
 
 import (
+	"errors"
+	"log"
+
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/selftest/common"
 )
 
 func main() {
+	kernelVersion := common.GetKernelVersion()
+	kernelRelease := common.GetKernelRelease()
+	log.Printf("Running on kernel: %s", kernelVersion)
+	log.Printf("Kernel release: %s", kernelRelease)
+
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {
 		common.Error(err)
@@ -21,9 +29,17 @@ func main() {
 
 	// Should be supported from 5.8 onwards
 	isSupported, err := bpf.BPFMapTypeIsSupported(bpf.MapTypeRingbuf)
-	if err != nil || !isSupported {
+
+	log.Printf("BPFMapTypeIsSupported(MapTypeRingbuf) returned: isSupported=%v, err=%v", isSupported, err)
+
+	if err != nil {
 		common.Error(err)
 	}
+	if !isSupported {
+		common.Error(errors.New("ringbuf is not supported on this kernel (expected supported from 5.8 onwards)"))
+	}
+
+	log.Println("Ringbuf is supported as expected")
 
 	eventsChannel1 := make(chan []byte)
 	_, err = bpfModule.InitRingBuf("events1", eventsChannel1)

--- a/selftest/probe-ringbuf/run.sh
+++ b/selftest/probe-ringbuf/run.sh
@@ -7,7 +7,7 @@ KERNEL_VERSION=v5.8    # kernel version
 # SETTINGS
 COMMON="$(dirname $0)/../common/common.sh"
 
-vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
+vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --append "psi=0" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
 # Don't override the exit code from the VM
 exit $?

--- a/selftest/probe-ringbuf/run.sh
+++ b/selftest/probe-ringbuf/run.sh
@@ -9,4 +9,5 @@ COMMON="$(dirname $0)/../common/common.sh"
 
 vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
-exit 0
+# Don't override the exit code from the VM
+exit $?

--- a/selftest/struct-ops/run.sh
+++ b/selftest/struct-ops/run.sh
@@ -7,7 +7,7 @@ KERNEL_VERSION=v6.12.2    # kernel version
 # SETTINGS
 COMMON="$(dirname $0)/../common/common.sh"
 
-vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
+vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --append "psi=0" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
 # Don't override the exit code from the VM
 exit $?

--- a/selftest/struct-ops/run.sh
+++ b/selftest/struct-ops/run.sh
@@ -9,4 +9,5 @@ COMMON="$(dirname $0)/../common/common.sh"
 
 vng -v -r $KERNEL_VERSION --rodir="$(realpath ..)" --  "export TEST=$TEST COMMON=$COMMON TIMEOUT=$TIMEOUT; ./run-vm.sh"
 
-exit 0
+# Don't override the exit code from the VM
+exit $?


### PR DESCRIPTION
Close: #509

commit 4ef41b9ebd75e636cab3d99c3137708ed250afa2

    fix(selftest): fix random ENOSPC expected failures
    
    This also enhances logging for batch ops tests.

commit 29a6f50c6a2f515ed2fac9df64a787701e669377

    fix(selftest): disable psi for vng tests
    
    Some vng kernels fail depending on the host environment. For instance,
    on 6.15.11-2-MANJARO, 5.7 fails with kernel panic.

commit 386b15f82a3213cda3e7b04cc30ac070f4fb67b1

    fix(selftest): do not override exitcode

commit 94a57446b3d2ee63badaf2b5bab45d1f0e83eea0

    chore: add GetKernelVersion and GetKernelRelease ...
    
    ... to provide more information to the selftests.