### PR TITLE
Add SkipMemlockBump to NewModuleBufferArgs

### DIFF
--- a/module.go
+++ b/module.go
@@ -115,9 +115,12 @@ func NewModuleFromBufferArgs(args NewModuleArgs) (*Module, error) {
 	}
 	C.cgo_libbpf_set_print_fn()
 
-	// TODO: remove this once libbpf memory limit bump issue is solved
-	if err := bumpMemlockRlimit(); err != nil {
-		return nil, err
+	// If skipped, we rely on libbpf to do the bumping if deemed necessary
+	if !args.SkipMemlockBump {
+		// TODO: remove this once libbpf memory limit bump issue is solved
+		if err := bumpMemlockRlimit(); err != nil {
+			return nil, err
+		}
 	}
 
 	var btfFilePathC *C.char


### PR DESCRIPTION
This is part of the patch [1] that was applied to NewModuleFromFileArgs, but not to NewModuleFromBufferArgs.
This commit applies the same patch to NewModuleFromBufferArgs.

The goal was to remove the `CAP_SYS_RESOURCE` requirement since the rlimit bump was the only remaining one to require that.
Skipping the memory lock bump with the BPF module option introduced by the initial patch [1], will make the program to rely on libbpf that relies on cgroup managed memory accounting [2].

1. https://github.com/aquasecurity/libbpfgo/commit/d2cc6f8a97da4fabbf1613dea7a5a9a1656463bd
2. https://lore.kernel.org/bpf/20201201215900.3569844-1-guro@fb.com/t/

See also #489