### PR TITLE
feat: add support for bpf_program__attach_uprobe_opts

### DIFF
--- a/libbpfgo.c
+++ b/libbpfgo.c
@@ -168,6 +168,25 @@ struct bpf_link *cgo_bpf_program__attach_uprobe_multi(
     return bpf_program__attach_uprobe_multi(prog, pid, binary_path, func_pattern, &opts);
 }
 
+struct bpf_link *cgo_bpf_program__attach_uprobe_opts(
+    struct bpf_program *prog,
+    pid_t pid,
+    const char *binary_path,
+    size_t func_offset,
+    size_t ref_ctr_offset,
+    __u64 bpf_cookie,
+    bool retprobe
+)
+{
+    struct bpf_uprobe_opts opts = {};
+    opts.sz = sizeof(opts);
+    opts.ref_ctr_offset = ref_ctr_offset;
+    opts.bpf_cookie = bpf_cookie;
+    opts.retprobe = retprobe;
+
+    return bpf_program__attach_uprobe_opts(prog, pid, binary_path, func_offset, &opts);
+}
+
 //
 // struct handlers
 //

--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -40,6 +40,14 @@ struct bpf_link *cgo_bpf_program__attach_uprobe_multi(struct bpf_program *prog,
                                                       size_t count,
                                                       bool retprobe);
 
+struct bpf_link *cgo_bpf_program__attach_uprobe_opts(struct bpf_program *prog,
+                                                      pid_t pid,
+                                                      const char *binary_path,
+                                                      size_t func_offset,
+                                                      size_t ref_ctr_offset,
+                                                      __u64 bpf_cookie,
+                                                      bool retprobe);
+
 //
 // struct handlers
 //

--- a/prog.go
+++ b/prog.go
@@ -628,6 +628,30 @@ func (p *BPFProg) AttachURetprobe(pid int, path string, offset uint64) (*BPFLink
 	return doAttachUprobe(p, true, pid, absPath, offset)
 }
 
+// AttachUprobeWithOpts attaches the BPFProgram to entry of the symbol in the library or binary at 'path'
+// which can be relative or absolute, with a bpf_cookie value retrievable via bpf_get_attach_cookie().
+// A pid can be provided to attach to, or -1 can be specified to attach to all processes.
+func (p *BPFProg) AttachUprobeWithOpts(pid int, path string, offset uint64, cookie uint64) (*BPFLink, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return doAttachUprobeOpts(p, false, pid, absPath, offset, 0, cookie)
+}
+
+// AttachURetprobeWithOpts attaches the BPFProgram to exit of the symbol in the library or binary at 'path'
+// which can be relative or absolute, with a bpf_cookie value retrievable via bpf_get_attach_cookie().
+// A pid can be provided to attach to, or -1 can be specified to attach to all processes.
+func (p *BPFProg) AttachURetprobeWithOpts(pid int, path string, offset uint64, cookie uint64) (*BPFLink, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return doAttachUprobeOpts(p, true, pid, absPath, offset, 0, cookie)
+}
+
 // AttachUprobeMulti attaches the BPFProgram to entry of the symbol in the library or binary at 'path'
 // which can be relative or absolute, using the uprobe_multi link, allowing to specify multiple offsets.
 // A pid can be provided to attach to, or -1 can be specified to attach to all processes.
@@ -669,6 +693,38 @@ func doAttachUprobe(prog *BPFProg, isUretprobe bool, pid int, path string, offse
 	)
 	if linkC == nil {
 		return nil, fmt.Errorf("failed to attach u(ret)probe to program %s:%d with pid %d: %w ", path, offset, pid, errno)
+	}
+
+	upType := Uprobe
+	if isUretprobe {
+		upType = Uretprobe
+	}
+
+	bpfLink := &BPFLink{
+		link:      linkC,
+		prog:      prog,
+		linkType:  upType,
+		eventName: fmt.Sprintf("%s:%d:%d", path, pid, offset),
+	}
+
+	return bpfLink, nil
+}
+
+func doAttachUprobeOpts(prog *BPFProg, isUretprobe bool, pid int, path string, offset uint64, refCtrOffset uint64, cookie uint64) (*BPFLink, error) {
+	pathC := C.CString(path)
+	defer C.free(unsafe.Pointer(pathC))
+
+	linkC, errno := C.cgo_bpf_program__attach_uprobe_opts(
+		prog.prog,
+		C.int(pid),
+		pathC,
+		C.size_t(offset),
+		C.size_t(refCtrOffset),
+		C.__u64(cookie),
+		C.bool(isUretprobe),
+	)
+	if linkC == nil {
+		return nil, fmt.Errorf("failed to attach u(ret)probe to program %s:%d with pid %d: %w", path, offset, pid, errno)
 	}
 
 	upType := Uprobe

--- a/selftest/uprobe-cookie/Makefile
+++ b/selftest/uprobe-cookie/Makefile
@@ -1,0 +1,105 @@
+BASEDIR = $(abspath ../../)
+
+OUTPUT = ../../output
+
+LIBBPF_SRC = $(abspath ../../libbpf/src)
+LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
+
+CC = gcc
+CLANG = clang
+GO ?= go
+PKGCONFIG = pkg-config
+
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/g; s/aarch64/arm64/g')
+
+# libbpf
+
+LIBBPF_OBJDIR = $(abspath ./$(OUTPUT)/libbpf)
+
+CFLAGS = -g -O2 -Wall -fpie
+LDFLAGS =
+
+CGO_CFLAGS_STATIC = "-I$(abspath $(OUTPUT)) -I$(abspath ../common)"
+CGO_LDFLAGS_STATIC = "$(shell PKG_CONFIG_PATH=$(LIBBPF_OBJDIR) $(PKGCONFIG) --static --libs libbpf)"
+CGO_EXTLDFLAGS_STATIC = '-w -extldflags "-static"'
+
+CGO_CFLAGS_DYN = "-I. -I/usr/include/"
+CGO_LDFLAGS_DYN = "$(shell $(PKGCONFIG) --shared --libs libbpf)"
+
+TEST = main
+
+.PHONY: $(TEST)
+.PHONY: $(TEST).go
+.PHONY: $(TEST).bpf.c
+
+all: $(TEST)-static
+
+.PHONY: libbpfgo
+.PHONY: libbpfgo-static
+.PHONY: libbpfgo-dynamic
+
+## libbpfgo
+
+libbpfgo-static:
+	$(MAKE) -C $(BASEDIR) libbpfgo-static
+
+libbpfgo-dynamic:
+	$(MAKE) -C $(BASEDIR) libbpfgo-dynamic
+
+## test (bpf)
+
+$(TEST).bpf.o: $(TEST).bpf.c
+	$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH) -I$(OUTPUT) -I$(abspath ../common) -c $< -o $@
+
+## test deps
+
+DEPS = ctest gotest
+
+.PHONY: ctest
+ctest:
+	@if [ ! -x ctest ]; then \
+		$(CLANG) -o ctest test.c; \
+	fi
+
+.PHONY: gotest
+gotest:
+	@if [ ! -x gotest ]; then \
+		$(GO) build -o gotest test.go; \
+	 fi
+
+## test
+
+.PHONY: $(TEST)-static
+.PHONY: $(TEST)-dynamic
+
+$(TEST)-static: libbpfgo-static | $(TEST).bpf.o $(DEPS)
+	CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_STATIC) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_STATIC) \
+		GOOS=linux GOARCH=$(ARCH) \
+		$(GO) build \
+		-tags netgo -ldflags $(CGO_EXTLDFLAGS_STATIC) \
+		-o $(TEST)-static ./$(TEST).go
+
+$(TEST)-dynamic: libbpfgo-dynamic | $(TEST).bpf.o $(DEPS)
+	CC=$(CLANG) \
+		CGO_CFLAGS=$(CGO_CFLAGS_DYN) \
+		CGO_LDFLAGS=$(CGO_LDFLAGS_DYN) \
+		$(GO) build -o ./$(TEST)-dynamic ./$(TEST).go
+
+## run
+
+.PHONY: run
+.PHONY: run-static
+.PHONY: run-dynamic
+
+run: run-static
+
+run-static: $(TEST)-static
+	sudo ./run.sh $(TEST)-static
+
+run-dynamic: $(TEST)-dynamic
+	sudo ./run.sh $(TEST)-dynamic
+
+clean:
+	rm -f *.o $(TEST)-static $(TEST)-dynamic $(DEPS)

--- a/selftest/uprobe-cookie/go.mod
+++ b/selftest/uprobe-cookie/go.mod
@@ -1,0 +1,14 @@
+module github.com/aquasecurity/libbpfgo/selftest/uprobe-cookie
+
+go 1.21
+
+require (
+	github.com/aquasecurity/libbpfgo v0.0.0
+	github.com/aquasecurity/libbpfgo/selftest/common v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/aquasecurity/libbpfgo => ../../
+
+replace github.com/aquasecurity/libbpfgo/helpers => ../../helpers
+
+replace github.com/aquasecurity/libbpfgo/selftest/common => ../../selftest/common

--- a/selftest/uprobe-cookie/go.sum
+++ b/selftest/uprobe-cookie/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.76 h1:mrdLPj8ujM6eIKGtd1PkkuCIodpFFDM42Cfm0YODkIM=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.76/go.mod h1:7V2BQeHnVAQwhCnCPJ977giCeGDiywVewWF+8vkpPlc=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 h1:3DyzQ30OHt3wiOZVL1se2g1PAPJIU7+tMUyvfMUj1dY=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=

--- a/selftest/uprobe-cookie/main.bpf.c
+++ b/selftest/uprobe-cookie/main.bpf.c
@@ -1,0 +1,39 @@
+//+build ignore
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+struct event_t {
+    __u64 cookie;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 24);
+} events SEC(".maps");
+
+long ringbuffer_flags = 0;
+
+SEC("uprobe/test_functions")
+int uprobe__test_functions(struct pt_regs *ctx)
+{
+    __u64 cookie = bpf_get_attach_cookie(ctx);
+
+    bpf_printk("handle user function with cookie %llu\n", cookie);
+
+    // Reserve space on the ringbuffer for the sample
+    struct event_t *event = bpf_ringbuf_reserve(&events, sizeof(struct event_t), ringbuffer_flags);
+    if (!event) {
+        bpf_printk("error submitting event to ring buffer for user function with cookie %llu\n",
+                   cookie);
+        return 0;
+    }
+
+    // Send back to userspace the function name
+    event->cookie = cookie;
+    bpf_ringbuf_submit(event, ringbuffer_flags);
+    return 0;
+}
+char __license[] SEC("license") = "GPL";

--- a/selftest/uprobe-cookie/main.go
+++ b/selftest/uprobe-cookie/main.go
@@ -1,0 +1,147 @@
+package main
+
+import "C"
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/libbpfgo/selftest/common"
+)
+
+type Event struct {
+	Cookie uint64
+}
+
+type FunctionInfo struct {
+	Name   string
+	Offset uint64
+}
+
+const (
+	bpfProgramName   = "uprobe__test_functions"
+	bpfProgramObject = "main.bpf.o"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		common.Error(errors.New("wrong syntax"))
+	}
+
+	// Executable and expected symbols to be traced as positional arguments.
+	binaryPath := os.Args[1]
+	expectedSymbolNames := strings.Split(os.Args[2], ",")
+
+	// Build cookie-to-function mapping for expected symbols.
+	cookieToFunctionInfo := make(map[uint64]FunctionInfo)
+	type probeTarget struct {
+		offset uint64
+		cookie uint64
+	}
+	var targets []probeTarget
+
+	for _, name := range expectedSymbolNames {
+		offset, err := common.SymbolToOffset(binaryPath, name)
+		if err != nil {
+			common.Error(fmt.Errorf("failed to resolve symbol %s: %v", name, err))
+		}
+		cookie := hash(name)
+		targets = append(targets, probeTarget{offset: offset, cookie: cookie})
+		cookieToFunctionInfo[cookie] = FunctionInfo{
+			Name:   name,
+			Offset: offset,
+		}
+	}
+
+	bpfModule, err := bpf.NewModuleFromFile(bpfProgramObject)
+	if err != nil {
+		common.Error(err)
+	}
+	defer bpfModule.Close()
+
+	if err = common.ResizeMap(bpfModule, "events", 8192); err != nil {
+		common.Error(err)
+	}
+
+	log.Println("getting program")
+	prog, err := bpfModule.GetProgram(bpfProgramName)
+	if err != nil {
+		common.Error(err)
+	}
+
+	log.Println("loading object")
+	err = bpfModule.BPFLoadObject()
+	if err != nil {
+		common.Error(err)
+	}
+
+	// Attach individual uprobes with per-attachment cookies.
+	log.Println("attaching uprobes with cookies")
+	for _, t := range targets {
+		_, err = prog.AttachUprobeWithOpts(-1, binaryPath, t.offset, t.cookie)
+		if err != nil {
+			common.Error(fmt.Errorf("failed to attach uprobe at offset %d with cookie %d: %v", t.offset, t.cookie, err))
+		}
+	}
+
+	log.Println("initializing events ring buffer")
+	eventsChannel := make(chan []byte)
+	rb, err := bpfModule.InitRingBuf("events", eventsChannel)
+	if err != nil {
+		common.Error(err)
+	}
+
+	rb.Poll(300)
+
+	// We get back from BPF and keep track of the function having traced via cookies.
+	log.Println("consuming events")
+	got := make(map[string]struct{})
+	go func() {
+		for {
+			b := <-eventsChannel
+			var event Event
+			buf := bytes.NewBuffer(b)
+			if err = binary.Read(buf, binary.LittleEndian, &event); err != nil {
+				continue
+			}
+			cookie := event.Cookie
+			info, ok := cookieToFunctionInfo[cookie]
+			if !ok {
+				continue
+			}
+			got[info.Name] = struct{}{}
+		}
+	}()
+	// Just wait for a minimum amount of time for the tested tracee to call
+	// the expected functions.
+	time.Sleep(2 * time.Second)
+
+	// Verify that all uprobes have been executed.
+	for _, symbolName := range expectedSymbolNames {
+		if _, ok := got[symbolName]; !ok {
+			common.Error(fmt.Errorf("function %s has not been traced", symbolName))
+		}
+	}
+	log.Println("all functions have been traced with correct cookies")
+
+	// Test that it won't cause a panic or block if Stop or Close called multiple times
+	rb.Stop()
+	rb.Stop()
+	rb.Close()
+	rb.Close()
+	rb.Stop()
+}
+
+func hash(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+
+	return h.Sum64()
+}

--- a/selftest/uprobe-cookie/run.sh
+++ b/selftest/uprobe-cookie/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# SETTINGS
+
+TEST=$(dirname $0)/$1  # execute
+TIMEOUT=10             # seconds
+
+CTEST=$(dirname $0)/ctest
+GOTEST=$(dirname $0)/gotest
+CFUNCS="fooFunction,barFunction,bazFunction"
+GOFUNCS="main.fooFunction,main.barFunction,main.bazFunction"
+
+# COMMON
+
+COMMON="$(dirname $0)/../common/common.sh"
+[[ -f $COMMON ]] && { . $COMMON; } || { error "no common"; exit 1; }
+
+# MAIN
+
+kern_version gt 5.15
+check_build
+check_ppid
+
+execbg 10 $CTEST
+execbg 10 $GOTEST
+
+execfg 5 $TEST $CTEST $CFUNCS
+test_step
+
+execfg 5 $TEST $GOTEST $GOFUNCS
+test_finish
+
+waitbg
+
+exit 0

--- a/selftest/uprobe-cookie/test.c
+++ b/selftest/uprobe-cookie/test.c
@@ -1,0 +1,20 @@
+//+build ignore
+#include <unistd.h>
+
+__attribute__((optnone)) void fooFunction() {}
+__attribute__((optnone)) void barFunction() {}
+__attribute__((optnone)) void bazFunction() {}
+
+int main()
+{
+    int i;
+
+    while (1) {
+        usleep(100 * 1000);
+        fooFunction();
+        usleep(100 * 1000);
+        barFunction();
+        usleep(100 * 1000);
+        bazFunction();
+    }
+}

--- a/selftest/uprobe-cookie/test.go
+++ b/selftest/uprobe-cookie/test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+//go:noinline
+func fooFunction() int {
+	if os.Getenv("SELFTEST_UPROBE_DO_BRANCH") == "y" {
+		return 1
+	}
+	return 0
+}
+
+//go:noinline
+func barFunction() int {
+	if os.Getenv("SELFTEST_UPROBE_DO_BRANCH") == "y" {
+		return 1
+	}
+	return 0
+}
+
+//go:noinline
+func bazFunction() int {
+	if os.Getenv("SELFTEST_UPROBE_DO_BRANCH") == "y" {
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	for {
+		time.Sleep(100 * time.Millisecond)
+		fooFunction()
+		time.Sleep(100 * time.Millisecond)
+		barFunction()
+		time.Sleep(100 * time.Millisecond)
+		bazFunction()
+	}
+}


### PR DESCRIPTION
Add a Go wrapper for `bpf_program__attach_uprobe_opts` that accepts at minimum a `bpf_cookie` parameter, returning a `*BPFLink` as with the existing `AttachUprobe`.

New selftests are included accordingly.

Closes #522 