### PR TITLE
feat: add AttachTCX support

### DIFF
--- a/link.go
+++ b/link.go
@@ -29,6 +29,7 @@ const (
 	Uretprobe
 	Tracing
 	XDP
+	TCX // traffic control eXpress (new attachment type)
 	Cgroup
 	CgroupLegacy
 	Netns

--- a/selftest/tracing-by-offset/go.mod
+++ b/selftest/tracing-by-offset/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/libbpfgo/selftest/tracing-by-offset
 go 1.21
 
 require (
-	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b
+	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.6.3
 	github.com/aquasecurity/libbpfgo/selftest/common v0.0.0-00010101000000-000000000000
 )
 

--- a/selftest/tracing/go.mod
+++ b/selftest/tracing/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/libbpfgo/selftest/tracing
 go 1.21
 
 require (
-	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b
+	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.6.3
 	github.com/aquasecurity/libbpfgo/selftest/common v0.0.0-00010101000000-000000000000
 )
 


### PR DESCRIPTION
Add AttachTCX support.
AttachTCX attaches the BPF program via the TCX helper.
The behaviour is analogous to AttachXDP but uses the `bpf_program__attach_tcx` call introduced in newer kernels.